### PR TITLE
feat: add push check for lint, typo

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,23 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
+
+      - name: gofumpt -s with reviewdog
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go install mvdan.cc/gofumpt@v0.2.0
+          gofumpt -e -d . | \
+          reviewdog -name="gofumpt" -f=diff -f.diff.strip=0 -reporter=github-pr-review

--- a/.github/workflows/typo-check.yml
+++ b/.github/workflows/typo-check.yml
@@ -1,0 +1,12 @@
+name: Typo Check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: typos-action
+        uses: crate-ci/typos@v1.3.3

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+# Typo check: https://github.com/crate-ci/typos
+
+[files]
+extend-exclude = ["*.json", "*.js", "static/*", "layouts/*", "assets/*", "i18n/*", "go.*"]
+
+[default.extend-words]
+datas = "datas"


### PR DESCRIPTION
Nutsdb currently only integrated unit test in github workflows. I think it would be better to  add Golang linter and typo check for future development. 