### PR TITLE
fix: update golang.org/x/sys to support go1.18 build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.13
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cespare/xxhash/v2 v2.1.2
-	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/stretchr/testify v1.7.1
 	github.com/xujiajun/gorouter v1.2.0
 	github.com/xujiajun/mmap-go v1.0.1
 	github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b
+	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -16,8 +15,10 @@ github.com/xujiajun/mmap-go v1.0.1 h1:7Se7ss1fLPPRW+ePgqGpCkfGIZzJV6JPq9Wq9iv/WH
 github.com/xujiajun/mmap-go v1.0.1/go.mod h1:CNN6Sw4SL69Sui00p0zEzcZKbt+5HtEnYUsc6BKKRMg=
 github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b h1:jKG9OiL4T4xQN3IUrhUpc1tG+HfDXppkgVcrAiiaI/0=
 github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b/go.mod h1:AZd87GYJlUzl82Yab2kTjx1EyXSQCAfZDhpTo1SQC4k=
-golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6 h1:IcgEB62HYgAhX0Nd/QrVgZlxlcyxbGQHElLUhW2X4Fo=
 golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 h1:kHVeDEnfKn3T238CvrUcz6KeEsFHVaKh4kMTt6Wsysg=
+golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Currently go build/test will fail if you're using Golang 1.18. Here's the output:
```
# golang.org/x/sys/unix
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20181221143128-b4a75ba826a6/unix/zsyscall_darwin_amd64.go:166:3: too many errors
FAIL    github.com/xujiajun/nutsdb [build failed]
```

This was caused by an old version of golang.org/x/sys (mentioned in [this issue](https://github.com/golang/go/issues/49219)).

This PR simply update golang.org/x/sys to support go1.18. I've already test it locally.