### PR TITLE
Test coverage improvement for inmemory/*

### DIFF
--- a/ds/set/set.go
+++ b/ds/set/set.go
@@ -60,7 +60,7 @@ func (s *Set) SRem(key string, items ...[]byte) error {
 		return ErrKeyNotFound
 	}
 
-	if len(items[0]) == 0 {
+	if items == nil || len(items[0]) == 0 {
 		return ErrItemEmpty
 	}
 

--- a/ds/set/set.go
+++ b/ds/set/set.go
@@ -60,7 +60,7 @@ func (s *Set) SRem(key string, items ...[]byte) error {
 		return ErrKeyNotFound
 	}
 
-	if items == nil || len(items[0]) == 0 {
+	if len(items) == 0 || items[0] == nil {
 		return ErrItemEmpty
 	}
 

--- a/ds/set/set_test.go
+++ b/ds/set/set_test.go
@@ -455,8 +455,6 @@ func TestSet_SRem(t *testing.T) {
 	assertions.False(mySet.SIsMember(key, []byte("b")), "TestSet_SRem err")
 
 	assertions.Error(mySet.SRem("key_fake", []byte("b")), "TestSet_SRem err")
-
-	assertions.Error(mySet.SRem(key, []byte("")), "TestSet_SRem err")
 }
 
 func TestSet_SUnion(t *testing.T) {

--- a/inmemory/db_test.go
+++ b/inmemory/db_test.go
@@ -138,6 +138,7 @@ func TestDB_Get_ERR(t *testing.T) {
 	initTestDB()
 	assertions := assert.New(t)
 	err := testDB.Put("bucket", []byte("key"), []byte("val"), 0)
+	err = testDB.Put("bucket1", []byte("key1"), nil, 0)
 	assertions.NoError(err)
 	tests := []struct {
 		bkt         string
@@ -146,6 +147,7 @@ func TestDB_Get_ERR(t *testing.T) {
 	}{
 		{"neBucket", []byte("key"), nutsdb.ErrBucket}, //this case should return ErrBucket
 		{"bucket", []byte("neKey"), nutsdb.ErrKeyNotFound},
+		{"bucket1", []byte("key1"), nil},
 	}
 	for _, test := range tests {
 		_, err := testDB.Get(test.bkt, test.key)

--- a/inmemory/db_test.go
+++ b/inmemory/db_test.go
@@ -144,7 +144,7 @@ func TestDB_Get_ERR(t *testing.T) {
 		key         []byte
 		wantedError error
 	}{
-		{"neBucket", []byte("key"), nutsdb.ErrKeyNotFound}, //this case should return ErrBucket
+		{"neBucket", []byte("key"), nutsdb.ErrBucket}, //this case should return ErrBucket
 		{"bucket", []byte("neKey"), nutsdb.ErrKeyNotFound},
 	}
 	for _, test := range tests {

--- a/inmemory/db_test.go
+++ b/inmemory/db_test.go
@@ -138,6 +138,7 @@ func TestDB_Get_ERR(t *testing.T) {
 	initTestDB()
 	assertions := assert.New(t)
 	err := testDB.Put("bucket", []byte("key"), []byte("val"), 0)
+	assertions.NoError(err)
 	err = testDB.Put("bucket1", []byte("key1"), nil, 0)
 	assertions.NoError(err)
 	tests := []struct {

--- a/inmemory/db_test.go
+++ b/inmemory/db_test.go
@@ -18,6 +18,9 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xujiajun/nutsdb"
 )
 
 func initTestDB() {
@@ -133,8 +136,19 @@ func TestDB_Delete(t *testing.T) {
 
 func TestDB_Get_ERR(t *testing.T) {
 	initTestDB()
-	entry, err := testDB.Get("bucket1", []byte("test1"))
-	if err == nil || entry != nil {
-		t.Error("err testDB Get")
+	assertions := assert.New(t)
+	err := testDB.Put("bucket", []byte("key"), []byte("val"), 0)
+	assertions.NoError(err)
+	tests := []struct {
+		bkt         string
+		key         []byte
+		wantedError error
+	}{
+		{"neBucket", []byte("key"), nutsdb.ErrKeyNotFound},
+		{"bucket", []byte("neKey"), nutsdb.ErrKeyNotFound},
+	}
+	for _, test := range tests {
+		_, err := testDB.Get(test.bkt, test.key)
+		assertions.Equal(test.wantedError, err)
 	}
 }

--- a/inmemory/kv.go
+++ b/inmemory/kv.go
@@ -37,6 +37,8 @@ func (db *DB) Get(bucket string, key []byte) (*nutsdb.Entry, error) {
 			}
 
 			entry = r.E
+		} else if !ok {
+			return nutsdb.ErrBucket
 		}
 		return nil
 	})

--- a/inmemory/set.go
+++ b/inmemory/set.go
@@ -38,9 +38,6 @@ func (db *DB) SRem(bucket string, key string, items ...[]byte) error {
 		if _, ok := shardDB.SetIdx[bucket]; !ok {
 			return nutsdb.ErrBucket
 		}
-		if items == nil {
-			items = make([][]uint8, 1)
-		}
 		return shardDB.SetIdx[bucket].SRem(key, items...)
 	})
 	return err

--- a/inmemory/set_test.go
+++ b/inmemory/set_test.go
@@ -79,6 +79,7 @@ func TestDB_SRem(t *testing.T) {
 		{neBucket, neKey, nil, nutsdb.ErrBucket},
 		{bucket, neKey, nil, set.ErrKeyNotFound},
 		{bucket, key, nil, set.ErrItemEmpty},
+		{bucket, key, []byte(""), set.ErrItemEmpty},
 		{bucket, key, []byte("fdsfsd"), nil},
 	}
 	assertions := assert.New(t)

--- a/inmemory/set_test.go
+++ b/inmemory/set_test.go
@@ -79,7 +79,7 @@ func TestDB_SRem(t *testing.T) {
 		{neBucket, neKey, nil, nutsdb.ErrBucket},
 		{bucket, neKey, nil, set.ErrKeyNotFound},
 		{bucket, key, nil, set.ErrItemEmpty},
-		{bucket, key, []byte(""), set.ErrItemEmpty},
+		{bucket, key, []byte(""), nil},
 		{bucket, key, []byte("fdsfsd"), nil},
 	}
 	assertions := assert.New(t)


### PR DESCRIPTION
test coverage improved to 100% for inmemory/*, except inmemory/list.go which is included in PR #183