### PR TITLE
make default options to be created in a factory method

### DIFF
--- a/inmemory/db.go
+++ b/inmemory/db.go
@@ -32,9 +32,11 @@ type (
 )
 
 // DefaultOptions default options
-var DefaultOptions = Options{
-	ShardsCount: 256,
-}
+var DefaultOptions = func() Options {
+	return Options{
+		ShardsCount: 256,
+	}
+}()
 
 func WithShardsCount(shardsCount uint64) Option {
 	return func(opt *Options) {

--- a/options.go
+++ b/options.go
@@ -65,14 +65,16 @@ type Options struct {
 var defaultSegmentSize int64 = 256 * 1024 * 1024
 
 // DefaultOptions represents the default options.
-var DefaultOptions = Options{
-	EntryIdxMode:         HintKeyValAndRAMIdxMode,
-	SegmentSize:          defaultSegmentSize,
-	NodeNum:              1,
-	RWMode:               FileIO,
-	SyncEnable:           true,
-	StartFileLoadingMode: MMap,
-}
+var DefaultOptions = func() Options {
+	return Options{
+		EntryIdxMode:         HintKeyValAndRAMIdxMode,
+		SegmentSize:          defaultSegmentSize,
+		NodeNum:              1,
+		RWMode:               FileIO,
+		SyncEnable:           true,
+		StartFileLoadingMode: MMap,
+	}
+}()
 
 type Option func(*Options)
 


### PR DESCRIPTION
I think it is better to get a default options by a factory method, because if i create two dbs in my appcations, and one have to change the default fields value in defalue_options, and the other can not feel the change. it is better to make every default options is a new object in memory.