### PR TITLE
feat: Add support for IterateBuckets regularized matching #194

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -331,8 +331,10 @@ IterateBuckets支持迭代指定ds的迭代。
 
 if err := db.View(
     func(tx *nutsdb.Tx) error {
-        return tx.IterateBuckets(nutsdb.DataStructureBPTree, func(bucket string) {
+        return tx.IterateBuckets(nutsdb.DataStructureBPTree, "*", func(bucket string) bool {
             fmt.Println("bucket: ", bucket)
+            // true: continue, false: break
+            return true
         })
     }); err != nil {
     log.Fatal(err)

--- a/README.md
+++ b/README.md
@@ -296,14 +296,18 @@ Also, this bucket is related to the data structure you use. Different data index
 
 #### Iterate buckets
 
-IterateBuckets iterates over all the bucket. IterateBuckets function has two parameters: `ds` and function `f`.
+IterateBuckets iterates over all the buckets that match the pattern. IterateBuckets function has three parameters: `ds`, `pattern` and function `f`.
 
 The current version of the Iterate Buckets method supports the following EntryId Modes:
 
 * `HintKeyValAndRAMIdxMode`：represents ram index (key and value) mode.
 * `HintKeyAndRAMIdxMode`：represents ram index (only key) mode.
 
-The current version of `ds` (represents the data structure)：
+The `pattern` added in version `0.11.0` (represents the pattern to match):
+
+* `pattern` syntax refer to: `filepath.Match`
+
+The current version of `ds` (represents the data structure):
 
 * DataStructureSet
 * DataStructureSortedSet
@@ -313,8 +317,10 @@ The current version of `ds` (represents the data structure)：
 ```go
 if err := db.View(
     func(tx *nutsdb.Tx) error {
-        return tx.IterateBuckets(nutsdb.DataStructureBPTree, func(bucket string) {
+        return tx.IterateBuckets(nutsdb.DataStructureBPTree, "*", func(bucket string) bool {
             fmt.Println("bucket: ", bucket)
+            // true: continue, false: break
+            return true
         })
     }); err != nil {
     log.Fatal(err)

--- a/examples/bucket/main.go
+++ b/examples/bucket/main.go
@@ -51,8 +51,9 @@ func main() {
 func iterateBuckets() {
 	if err := db.View(
 		func(tx *nutsdb.Tx) error {
-			return tx.IterateBuckets(nutsdb.DataStructureBPTree, func(bucket string) {
+			return tx.IterateBuckets(nutsdb.DataStructureBPTree, "*", func(bucket string) bool {
 				fmt.Println("bucket: ", bucket)
+				return true
 			})
 		}); err != nil {
 		log.Fatal(err)

--- a/tx_bucket.go
+++ b/tx_bucket.go
@@ -17,7 +17,7 @@ package nutsdb
 import "time"
 
 // IterateBuckets iterate over all the bucket depends on ds (represents the data structure)
-func (tx *Tx) IterateBuckets(ds uint16, f func(bucket string)) error {
+func (tx *Tx) IterateBuckets(ds uint16, pattern string, f func(key string) bool) error {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return err
 	}
@@ -26,22 +26,30 @@ func (tx *Tx) IterateBuckets(ds uint16, f func(bucket string)) error {
 	}
 	if ds == DataStructureSet {
 		for bucket := range tx.db.SetIdx {
-			f(bucket)
+			if end, err := MatchForRange(pattern, bucket, f); end || err != nil {
+				return err
+			}
 		}
 	}
 	if ds == DataStructureSortedSet {
 		for bucket := range tx.db.SortedSetIdx {
-			f(bucket)
+			if end, err := MatchForRange(pattern, bucket, f); end || err != nil {
+				return err
+			}
 		}
 	}
 	if ds == DataStructureList {
 		for bucket := range tx.db.ListIdx {
-			f(bucket)
+			if end, err := MatchForRange(pattern, bucket, f); end || err != nil {
+				return err
+			}
 		}
 	}
 	if ds == DataStructureBPTree {
 		for bucket := range tx.db.BPTreeIdx {
-			f(bucket)
+			if end, err := MatchForRange(pattern, bucket, f); end || err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/tx_bucket_test.go
+++ b/tx_bucket_test.go
@@ -78,27 +78,47 @@ func (suite *TxBucketTestSuite) TestA_IterateBuckets() {
 	tx, err := suite.Db.Begin(false)
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureSet, func(bucket string) {
+	err = tx.IterateBuckets(DataStructureSet, "*", func(bucket string) bool {
 		assert.Equal(suite.T(), "set_bucket", bucket)
+		return true
 	})
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureSortedSet, func(bucket string) {
+	err = tx.IterateBuckets(DataStructureSortedSet, "*", func(bucket string) bool {
 		assert.Equal(suite.T(), "zset_bucket", bucket)
+		return true
 	})
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureList, func(bucket string) {
+	err = tx.IterateBuckets(DataStructureList, "*", func(bucket string) bool {
 		assert.Equal(suite.T(), "list_bucket", bucket)
+		return true
 	})
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureBPTree, func(bucket string) {
+	err = tx.IterateBuckets(DataStructureBPTree, "*", func(bucket string) bool {
 		assert.Equal(suite.T(), "string_bucket", bucket)
+		return true
 	})
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureNone, func(bucket string) {})
+	matched := false
+	_ = tx.IterateBuckets(DataStructureBPTree, "str*", func(bucket string) bool {
+		matched = true
+		return true
+	})
+	assert.Equal(suite.T(), true, matched)
+
+	matched = false
+	_ = tx.IterateBuckets(DataStructureList, "str*", func(bucket string) bool {
+		matched = true
+		return true
+	})
+	assert.Equal(suite.T(), false, matched)
+
+	err = tx.IterateBuckets(DataStructureNone, "*", func(bucket string) bool {
+		return true
+	})
 	assert.Nil(suite.T(), err)
 
 	err = tx.Commit()
@@ -151,7 +171,9 @@ func (suite *TxBucketTestSuite) TestC_HintBPTSparseIdxMode() {
 	tx, err := suite.DbHBPT.Begin(false)
 	assert.Nil(suite.T(), err)
 
-	err = tx.IterateBuckets(DataStructureList, func(bucket string) {})
+	err = tx.IterateBuckets(DataStructureList, "*", func(bucket string) bool {
+		return true
+	})
 	assert.Error(suite.T(), err)
 
 	err = tx.DeleteBucket(DataStructureList, "")

--- a/tx_list.go
+++ b/tx_list.go
@@ -16,7 +16,6 @@ package nutsdb
 
 import (
 	"bytes"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -287,12 +286,8 @@ func (tx *Tx) LKeys(bucket, pattern string, f func(key string) bool) error {
 		return ErrBucket
 	}
 	for key := range tx.db.ListIdx[bucket].Items {
-		match, err := filepath.Match(pattern, key)
-		if err != nil {
+		if end, err := MatchForRange(pattern, key, f); end || err != nil {
 			return err
-		}
-		if match && !f(key) {
-			return nil
 		}
 	}
 	return nil

--- a/tx_set.go
+++ b/tx_set.go
@@ -15,7 +15,6 @@
 package nutsdb
 
 import (
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -310,12 +309,8 @@ func (tx *Tx) SKeys(bucket, pattern string, f func(key string) bool) error {
 		return ErrBucket
 	}
 	for key := range tx.db.SetIdx[bucket].M {
-		match, err := filepath.Match(pattern, key)
-		if err != nil {
+		if end, err := MatchForRange(pattern, key, f); end || err != nil {
 			return err
-		}
-		if match && !f(key) {
-			return nil
 		}
 	}
 	return nil

--- a/tx_zset.go
+++ b/tx_zset.go
@@ -17,7 +17,6 @@ package nutsdb
 import (
 	"bytes"
 	"errors"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -256,12 +255,8 @@ func (tx *Tx) ZKeys(bucket, pattern string, f func(key string) bool) error {
 		return ErrBucket
 	}
 	for key := range tx.db.SortedSetIdx[bucket].Dict {
-		match, err := filepath.Match(pattern, key)
-		if err != nil {
+		if end, err := MatchForRange(pattern, key, f); end || err != nil {
 			return err
-		}
-		if match && !f(key) {
-			return nil
 		}
 	}
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 )
 
@@ -69,4 +70,15 @@ func UnmarshalInts(data []byte) ([]int, error) {
 		ints = append(ints, int(i))
 	}
 	return ints, nil
+}
+
+func MatchForRange(pattern, key string, f func(key string) bool) (end bool, err error) {
+	match, err := filepath.Match(pattern, key)
+	if err != nil {
+		return true, err
+	}
+	if match && !f(key) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -56,3 +56,24 @@ func TestMarshalInts(t *testing.T) {
 	assertions.Equal(1, ints[0], "TestMarshalInts")
 	assertions.Equal(3, ints[1], "TestMarshalInts")
 }
+
+func TestMatchForRange(t *testing.T) {
+	assertions := assert.New(t)
+
+	end, err := MatchForRange("*", "hello", func(key string) bool {
+		return true
+	})
+	assertions.NoError(err, "TestMatchForRange")
+	assertions.False(end, "TestMatchForRange")
+
+	_, err = MatchForRange("[", "hello", func(key string) bool {
+		return true
+	})
+	assertions.Error(err, "TestMatchForRange")
+
+	end, err = MatchForRange("*", "hello", func(key string) bool {
+		return false
+	})
+	assertions.NoError(err, "TestMatchForRange")
+	assertions.True(end, "TestMatchForRange")
+}


### PR DESCRIPTION
Add support for IterateBuckets regularized matching #194 

- Incompatible updates for api: `IterateBuckets`

new api:

```go
func (tx *Tx) IterateBuckets(ds uint16, pattern string, f func(key string) bool) error
```