### PR TITLE
optimaze concurrent read performance

### DIFF
--- a/bucket_meta.go
+++ b/bucket_meta.go
@@ -72,7 +72,7 @@ func (bm *BucketMeta) Size() int64 {
 // ReadBucketMeta returns bucketMeta at given file path name.
 func ReadBucketMeta(name string) (bucketMeta *BucketMeta, err error) {
 	var off int64
-	fd, err := os.OpenFile(filepath.Clean(name), os.O_RDWR, 0644)
+	fd, err := os.OpenFile(filepath.Clean(name), os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return
 	}

--- a/bucket_meta.go
+++ b/bucket_meta.go
@@ -72,7 +72,7 @@ func (bm *BucketMeta) Size() int64 {
 // ReadBucketMeta returns bucketMeta at given file path name.
 func ReadBucketMeta(name string) (bucketMeta *BucketMeta, err error) {
 	var off int64
-	fd, err := os.OpenFile(filepath.Clean(name), os.O_CREATE|os.O_RDWR, 0644)
+	fd, err := os.OpenFile(filepath.Clean(name), os.O_RDWR, 0644)
 	if err != nil {
 		return
 	}

--- a/datafile.go
+++ b/datafile.go
@@ -58,15 +58,17 @@ func NewDataFile(path string, rwManager RWManager) *DataFile {
 	dataFile.pool = &sync.Pool{
 		New: func() interface{} {
 			buf := make([]byte, DataEntryHeaderSize)
-			return buf
+			return &buf
 		}}
 	return dataFile
 }
 
 // ReadAt returns entry at the given off(offset).
 func (df *DataFile) ReadAt(off int) (e *Entry, err error) {
-	buf := df.pool.Get().([]byte)
-	defer df.pool.Put(buf)
+	bufPointer := df.pool.Get().(*[]byte)
+	defer df.pool.Put(bufPointer)
+
+	buf := *bufPointer
 
 	if _, err := df.rwManager.ReadAt(buf, int64(off)); err != nil {
 		return nil, err

--- a/datafile.go
+++ b/datafile.go
@@ -47,7 +47,7 @@ type DataFile struct {
 	rwManager  RWManager
 }
 
-//NewDataFile will return a new DataFile Object.
+// NewDataFile will return a new DataFile Object.
 func NewDataFile(path string, rwManager RWManager) *DataFile {
 	dataFile := &DataFile{
 		path:      path,
@@ -79,6 +79,12 @@ func (df *DataFile) ReadAt(off int) (e *Entry, err error) {
 	off += DataEntryHeaderSize
 	dataSize := meta.BucketSize + meta.KeySize + meta.ValueSize
 
+	dataBuf := make([]byte, dataSize)
+	_, err = df.rwManager.ReadAt(dataBuf, int64(off))
+	if err != nil {
+		return nil, err
+	}
+
 	bucketLowBound := 0
 	bucketHighBound := meta.BucketSize
 	keyLowBound := bucketHighBound
@@ -86,11 +92,6 @@ func (df *DataFile) ReadAt(off int) (e *Entry, err error) {
 	valueLowBound := keyHighBound
 	valueHighBound := dataSize
 
-	dataBuf := make([]byte, dataSize)
-	_, err = df.rwManager.ReadAt(dataBuf, int64(off))
-	if err != nil {
-		return nil, err
-	}
 	// parse bucket
 	e.Meta.Bucket = dataBuf[bucketLowBound:bucketHighBound]
 	// parse key

--- a/db.go
+++ b/db.go
@@ -628,7 +628,7 @@ func (db *DB) buildBPTreeRootIdxes(dataFileIds []int) error {
 	for i := 0; i < len(dataFileIds[0:dataFileIdsSize-1]); i++ {
 		off = 0
 		path := db.getBPTRootPath(int64(dataFileIds[i]))
-		fd, err := os.OpenFile(filepath.Clean(path), os.O_RDWR, 0644)
+		fd, err := os.OpenFile(filepath.Clean(path), os.O_RDWR, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/db.go
+++ b/db.go
@@ -318,7 +318,7 @@ func (db *DB) View(fn func(tx *Tx) error) error {
 // 4. At last remove the merged files.
 //
 // Caveat: Merge is Called means starting multiple write transactions, and it
-// will effect the other write request. so execute it at the appropriate time.
+// will affect the other write request. so execute it at the appropriate time.
 func (db *DB) Merge() error {
 	var (
 		off                 int64
@@ -504,7 +504,7 @@ func (db *DB) getMaxFileIDAndFileIDs() (maxFileID int64, dataFileIds []int) {
 	return
 }
 
-// getActiveFileWriteOff returns the write offset of activeFile.
+// getActiveFileWriteOff returns the write-offset of activeFile.
 func (db *DB) getActiveFileWriteOff() (off int64, err error) {
 	off = 0
 	for {
@@ -628,7 +628,7 @@ func (db *DB) buildBPTreeRootIdxes(dataFileIds []int) error {
 	for i := 0; i < len(dataFileIds[0:dataFileIdsSize-1]); i++ {
 		off = 0
 		path := db.getBPTRootPath(int64(dataFileIds[i]))
-		fd, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_RDWR, 0644)
+		fd, err := os.OpenFile(filepath.Clean(path), os.O_RDWR, 0644)
 		if err != nil {
 			return err
 		}

--- a/file_manager.go
+++ b/file_manager.go
@@ -41,12 +41,7 @@ func (fm *fileManager) getDataFile(path string, capacity int64) (datafile *DataF
 		}
 	}
 
-	return &DataFile{
-		path:       path,
-		writeOff:   0,
-		ActualSize: 0,
-		rwManager:  rwManager,
-	}, nil
+	return NewDataFile(path, rwManager), nil
 }
 
 // getFileRWManager will return a FileIORWManager Object


### PR DESCRIPTION
For now, we have four steps for reading a entry from disk: read meta,  read bucket, read key, and read value. I think when we had read meta, we already konw the total length of bucket, key, and value, and the location of bucket, key, value is continuous in disk.So we can read bucket, key, value once, it can reduce syscall times from 4 to 2.
And the memery of meta can reuse, bucause it will parse into a object in go struct after it read from disk, so the buffer it malloc can be reuse in next time to read meta from disk.
Besides, I also write a benchmark test about this code change.
I also build a database which has 100 keys and different size value in local, and concurreny read it in 10 goroutines. 
And the result as below, first item is master performance, and the other is this branch

when value size is 50:
`BenchmarkConcurrentRead-10    	    2054	    663687 ns/op	   69053 B/op	    1303 allocs/op`
`BenchmarkConcurrentRead-10    	    3390	    406251 ns/op	   66724 B/op	    1103 allocs/op`

when value size is 256:
`BenchmarkConcurrentRead-10    	    1581	    745181 ns/op	   88255 B/op	    1303 allocs/op`
`BenchmarkConcurrentRead-10    	    4075	    395201 ns/op	   87511 B/op	    1103 allocs/op`

when value size is 512:
`BenchmarkConcurrentRead-10    	    1627	    759430 ns/op	  113887 B/op	    1303 allocs/op`
`BenchmarkConcurrentRead-10    	    2794	    404143 ns/op	  116339 B/op	    1103 allocs/op`

As we can see, this is a significant optimization.
