### PR TITLE
fix : In BPTSparse when combination of bucket and key is repeated

### DIFF
--- a/db.go
+++ b/db.go
@@ -584,7 +584,7 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 				})
 
 				if db.opt.EntryIdxMode == HintBPTSparseIdxMode {
-					db.BPTreeKeyEntryPosMap[string(entry.Meta.Bucket)+string(entry.Key)] = off
+					db.BPTreeKeyEntryPosMap[string(getNewKey(string(entry.Meta.Bucket), entry.Key))] = off
 				}
 
 				off += entry.Size()
@@ -670,9 +670,7 @@ func (db *DB) buildBPTreeIdx(bucket string, r *Record) error {
 }
 
 func (db *DB) buildActiveBPTreeIdx(r *Record) error {
-	newKey := r.H.Meta.Bucket
-	newKey = append(newKey, r.H.Key...)
-
+	newKey := getNewKey(string(r.H.Meta.Bucket), r.H.Key)
 	if err := db.ActiveBPTreeIdx.Insert(newKey, r.E, r.H, CountFlagEnabled); err != nil {
 		return fmt.Errorf("when build BPTreeIdx insert index err: %s", err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -125,6 +125,7 @@ func TestDB_BPTSparse(t *testing.T) {
 	InitOpt("", true)
 	opt.EntryIdxMode = HintBPTSparseIdxMode
 	db, err = Open(opt)
+	require.NoError(t, err)
 	defer db.Close()
 
 	bucket1 := "AA"

--- a/tx.go
+++ b/tx.go
@@ -194,7 +194,7 @@ func (tx *Tx) Commit() error {
 		offset := tx.db.ActiveFile.writeOff + int64(buff.Len())
 
 		if entry.Meta.Ds == DataStructureBPTree {
-			tx.db.BPTreeKeyEntryPosMap[string(entry.Meta.Bucket)+string(entry.Key)] = offset
+			tx.db.BPTreeKeyEntryPosMap[string(getNewKey(string(entry.Meta.Bucket), entry.Key))] = offset
 		}
 
 		if i == lastIndex {
@@ -391,8 +391,7 @@ func (tx *Tx) buildIdxes(writesLen int) {
 
 func (tx *Tx) buildBPTreeIdx(bucket string, entry, e *Entry, offset int64, countFlag bool) {
 	if tx.db.opt.EntryIdxMode == HintBPTSparseIdxMode {
-		newKey := []byte(bucket)
-		newKey = append(newKey, entry.Key...)
+		newKey := getNewKey(bucket, entry.Key)
 		_ = tx.db.ActiveBPTreeIdx.Insert(newKey, e, &Hint{
 			FileID:  tx.db.ActiveFile.fileID,
 			Key:     newKey,

--- a/tx_bptree.go
+++ b/tx_bptree.go
@@ -26,6 +26,9 @@ import (
 func getNewKey(bucket string, key []byte) []byte {
 	newKey := []byte(bucket)
 	newKey = append(newKey, key...)
+	//avoid dup
+	newKey = append(newKey, []byte(bucket)...)
+
 	return newKey
 }
 


### PR DESCRIPTION
When a bucket and key are concatenated and duplicate, the value of the previous bucket is overwritten，by modifying the concatenation method, the duplicate occurrence can be avoided
```
        newKey = append(newKey, key...)
```
change to 
```
	newKey = append(newKey, key...)
	newKey = append(newKey, []byte(bucket)...)
```