### PR TITLE
Use biobuf optimaze startspeed

### DIFF
--- a/db.go
+++ b/db.go
@@ -545,15 +545,15 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 	}
 
 	for _, dataID := range dataFileIds {
-		off = 0
 		fID := int64(dataID)
-		f, err := db.fm.getDataFile(db.getDataPath(fID), db.opt.SegmentSize)
+		path := db.getDataPath(fID)
+		f, err := newFileRecovery(path)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		for {
-			if entry, err := f.ReadAt(int(off)); err == nil {
+			if entry, err := f.readEntry(); err == nil {
 				if entry == nil {
 					break
 				}
@@ -599,7 +599,6 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 				if off >= db.opt.SegmentSize {
 					break
 				}
-				err := f.rwManager.Release()
 				if err != nil {
 					return nil, nil, err
 				}
@@ -607,7 +606,6 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 			}
 		}
 
-		err = f.rwManager.Release()
 		if err != nil {
 			return nil, nil, err
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -1172,17 +1172,3 @@ func withBPTSpareeIdxDB(t *testing.T, fn func(t *testing.T, db *DB)) {
 
 	withDBOption(t, opt, fn)
 }
-
-func BenchmarkRecovery(b *testing.B) {
-	b.ResetTimer()
-	b.StartTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err = Open(DefaultOptions,
-			WithEntryIdxMode(HintKeyAndRAMIdxMode),
-			WithRWMode(FileIO),
-			WithDir("/Users/chenzichang/GolandProjects/go-learn/nutsdb/bench/nutsdb"),
-		)
-	}
-	b.StopTimer()
-}

--- a/db_test.go
+++ b/db_test.go
@@ -1172,3 +1172,17 @@ func withBPTSpareeIdxDB(t *testing.T, fn func(t *testing.T, db *DB)) {
 
 	withDBOption(t, opt, fn)
 }
+
+func BenchmarkRecovery(b *testing.B) {
+	b.ResetTimer()
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err = Open(DefaultOptions,
+			WithEntryIdxMode(HintKeyAndRAMIdxMode),
+			WithRWMode(FileIO),
+			WithDir("/Users/chenzichang/GolandProjects/go-learn/nutsdb/bench/nutsdb"),
+		)
+	}
+	b.StopTimer()
+}

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -1,0 +1,70 @@
+package nutsdb
+
+import (
+	"bufio"
+	"encoding/binary"
+	"os"
+)
+
+//fileRecovery use bufio.Reader to read entry
+type fileRecovery struct {
+	reader *bufio.Reader
+}
+
+func newFileRecovery(path string) (fr *fileRecovery, err error) {
+	fd, err := os.OpenFile(path, os.O_RDWR, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	return &fileRecovery{
+		reader: bufio.NewReader(fd),
+	}, nil
+}
+
+func (fr *fileRecovery) readEntry() (e *Entry, err error) {
+	buf := make([]byte, DataEntryHeaderSize)
+
+	if _, err := fr.reader.Read(buf); err != nil {
+		return nil, err
+	}
+
+	meta := readMetaData(buf)
+
+	e = &Entry{
+		crc:  binary.LittleEndian.Uint32(buf[0:4]),
+		Meta: meta,
+	}
+
+	if e.IsZero() {
+		return nil, nil
+	}
+
+	dataSize := meta.BucketSize + meta.KeySize + meta.ValueSize
+
+	dataBuf := make([]byte, dataSize)
+	_, err = fr.reader.Read(dataBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketLowBound := 0
+	bucketHighBound := meta.BucketSize
+	keyLowBound := bucketHighBound
+	keyHighBound := meta.BucketSize + meta.KeySize
+	valueLowBound := keyHighBound
+	valueHighBound := dataSize
+
+	// parse bucket
+	e.Meta.Bucket = dataBuf[bucketLowBound:bucketHighBound]
+	// parse key
+	e.Key = dataBuf[keyLowBound:keyHighBound]
+	// parse value
+	e.Value = dataBuf[valueLowBound:valueHighBound]
+
+	crc := e.GetCrc(buf)
+	if crc != e.crc {
+		return nil, ErrCrc
+	}
+
+	return
+}


### PR DESCRIPTION
Use bufio.Reader to read entry from disk. Bufio.Reader will read a block(default size is 4KB) to its ring buffer  previously and copy the buffer to you when you read a data from it. It can reduce syscall nums. Here is the benchmark result:
`BenchmarkRecovery-10            1 2288482750 ns/op 1156858488 B/op 14041579 allocs/op`
`BenchmarkRecovery-10            4  265742781 ns/op 152531440 B/op  1089555 allocs/op`