### PR TITLE
add  buffer size of recovery reader as param

### DIFF
--- a/db.go
+++ b/db.go
@@ -548,7 +548,7 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 		off = 0
 		fID := int64(dataID)
 		path := db.getDataPath(fID)
-		f, err := newFileRecovery(path)
+		f, err := newFileRecovery(path, db.opt.BufferSizeOfRecovery)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/options.go
+++ b/options.go
@@ -57,6 +57,9 @@ type Options struct {
 
 	// CleanFdsCacheThreshold represents the maximum threshold for recycling fd, it should be between 0 and 1.
 	CleanFdsCacheThreshold float64
+
+	// BufferSizeOfRecovery represents the buffer size of recoveryReader buffer Size
+	BufferSizeOfRecovery int
 }
 
 const (

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -11,17 +11,18 @@ type fileRecovery struct {
 	reader *bufio.Reader
 }
 
-func newFileRecovery(path string) (fr *fileRecovery, err error) {
+func newFileRecovery(path string, bufSize int) (fr *fileRecovery, err error) {
 	fd, err := os.OpenFile(path, os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}
+	bufSize = calBufferSize(bufSize)
 	return &fileRecovery{
-		reader: bufio.NewReader(fd),
+		reader: bufio.NewReaderSize(fd, bufSize),
 	}, nil
 }
 
-// readEntry will read a Entry from disk.
+// readEntry will read an Entry from disk.
 func (fr *fileRecovery) readEntry() (e *Entry, err error) {
 	buf, err := fr.readData(DataEntryHeaderSize)
 	if err != nil {
@@ -71,4 +72,19 @@ func (fr *fileRecovery) readData(size uint32) (data []byte, err error) {
 		}
 	}
 	return data, nil
+}
+
+// calBufferSize calculates the buffer size of bufio.Reader
+// if the size < 4 * KB, use 4 * KB as the size of buffer in bufio.Reader
+// if the size > 4 * KB, use the nearly blockSize buffer as the size of buffer in bufio.Reader
+func calBufferSize(size int) int {
+	blockSize := 4 * KB
+	if size < blockSize {
+		return blockSize
+	}
+	hasRest := (size%blockSize == 0)
+	if hasRest {
+		return (size/blockSize + 1) * blockSize
+	}
+	return size
 }


### PR DESCRIPTION
add a field as the buffer size of the recovery reader, due to we don't know the entry situation of our database, so we need a 
 effective cache when we recover it. So needs a dynamic size cache whose size can be controlled by the user.