### PR TITLE
add options function of BufferSizeOfRecovery

### DIFF
--- a/options.go
+++ b/options.go
@@ -135,3 +135,9 @@ func WithCleanFdsCacheThreshold(threshold float64) Option {
 		opt.CleanFdsCacheThreshold = threshold
 	}
 }
+
+func WithBufferSizeOfRecovery(size int) Option {
+	return func(opt *Options) {
+		opt.BufferSizeOfRecovery = size
+	}
+}


### PR DESCRIPTION
Add options function to SizeOfRecoveryBuffer, can make the code more readable when you open a DB