### PR TITLE
add fd release logic to file recovery reader

### DIFF
--- a/db.go
+++ b/db.go
@@ -591,6 +591,8 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 				off += entry.Size()
 
 			} else {
+				// whatever which logic branch it will choose, we will release the fd.
+				_ = f.release()
 				if err == io.EOF {
 					break
 				}

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -8,6 +8,7 @@ import (
 
 // fileRecovery use bufio.Reader to read entry
 type fileRecovery struct {
+	fd     *os.File
 	reader *bufio.Reader
 }
 
@@ -16,6 +17,7 @@ func newFileRecovery(path string, bufSize int) (fr *fileRecovery, err error) {
 	if err != nil {
 		return nil, err
 	}
+	fr.fd = fd
 	bufSize = calBufferSize(bufSize)
 	return &fileRecovery{
 		reader: bufio.NewReaderSize(fd, bufSize),
@@ -87,4 +89,8 @@ func calBufferSize(size int) int {
 		return (size/blockSize + 1) * blockSize
 	}
 	return size
+}
+
+func (fr *fileRecovery) release() error {
+	return fr.fd.Close()
 }

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -17,9 +17,9 @@ func newFileRecovery(path string, bufSize int) (fr *fileRecovery, err error) {
 	if err != nil {
 		return nil, err
 	}
-	fr.fd = fd
 	bufSize = calBufferSize(bufSize)
 	return &fileRecovery{
+		fd:     fd,
 		reader: bufio.NewReaderSize(fd, bufSize),
 	}, nil
 }


### PR DESCRIPTION
add fd release logic to file recovery reader so that we call release resource after we read all entries from a data file.