### PR TITLE
rebuild parse meta func

### DIFF
--- a/datafile.go
+++ b/datafile.go
@@ -64,17 +64,19 @@ func (df *DataFile) ReadAt(off int) (e *Entry, err error) {
 		return nil, err
 	}
 
-	meta := readMetaData(buf)
-
 	e = &Entry{
-		crc:  binary.LittleEndian.Uint32(buf[0:4]),
-		Meta: meta,
+		crc: binary.LittleEndian.Uint32(buf[0:4]),
+	}
+	err = e.ParseMeta(buf)
+	if err != nil {
+		return nil, err
 	}
 
 	if e.IsZero() {
 		return nil, nil
 	}
 
+	meta := e.Meta
 	off += DataEntryHeaderSize
 	dataSize := meta.BucketSize + meta.KeySize + meta.ValueSize
 
@@ -121,19 +123,4 @@ func (df *DataFile) Close() (err error) {
 
 func (df *DataFile) Release() (err error) {
 	return df.rwManager.Release()
-}
-
-// readMetaData returns MetaData at given buf slice.
-func readMetaData(buf []byte) *MetaData {
-	return &MetaData{
-		Timestamp:  binary.LittleEndian.Uint64(buf[4:12]),
-		KeySize:    binary.LittleEndian.Uint32(buf[12:16]),
-		ValueSize:  binary.LittleEndian.Uint32(buf[16:20]),
-		Flag:       binary.LittleEndian.Uint16(buf[20:22]),
-		TTL:        binary.LittleEndian.Uint32(buf[22:26]),
-		BucketSize: binary.LittleEndian.Uint32(buf[26:30]),
-		Status:     binary.LittleEndian.Uint16(buf[30:32]),
-		Ds:         binary.LittleEndian.Uint16(buf[32:34]),
-		TxID:       binary.LittleEndian.Uint64(buf[34:42]),
-	}
 }

--- a/entry.go
+++ b/entry.go
@@ -140,3 +140,19 @@ func (e *Entry) ParsePayload(data []byte) error {
 	e.Value = data[valueLowBound:valueHighBound]
 	return nil
 }
+
+func (e *Entry) ParseMeta(buf []byte) error {
+	meta := &MetaData{
+		Timestamp:  binary.LittleEndian.Uint64(buf[4:12]),
+		KeySize:    binary.LittleEndian.Uint32(buf[12:16]),
+		ValueSize:  binary.LittleEndian.Uint32(buf[16:20]),
+		Flag:       binary.LittleEndian.Uint16(buf[20:22]),
+		TTL:        binary.LittleEndian.Uint32(buf[22:26]),
+		BucketSize: binary.LittleEndian.Uint32(buf[26:30]),
+		Status:     binary.LittleEndian.Uint16(buf[30:32]),
+		Ds:         binary.LittleEndian.Uint16(buf[32:34]),
+		TxID:       binary.LittleEndian.Uint64(buf[34:42]),
+	}
+	e.Meta = meta
+	return nil
+}

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -28,17 +28,17 @@ func (fr *fileRecovery) readEntry() (e *Entry, err error) {
 	if err != nil {
 		return nil, err
 	}
-	meta := readMetaData(buf)
 
 	e = &Entry{
-		crc:  binary.LittleEndian.Uint32(buf[0:4]),
-		Meta: meta,
+		crc: binary.LittleEndian.Uint32(buf[0:4]),
 	}
+	e.ParseMeta(buf)
 
 	if e.IsZero() {
 		return nil, nil
 	}
 
+	meta := e.Meta
 	dataSize := meta.BucketSize + meta.KeySize + meta.ValueSize
 
 	dataBuf, err := fr.readData(dataSize)

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -32,7 +32,10 @@ func (fr *fileRecovery) readEntry() (e *Entry, err error) {
 	e = &Entry{
 		crc: binary.LittleEndian.Uint32(buf[0:4]),
 	}
-	e.ParseMeta(buf)
+	err = e.ParseMeta(buf)
+	if err != nil {
+		return nil, err
+	}
 
 	if e.IsZero() {
 		return nil, nil


### PR DESCRIPTION
rebuild the parse meta func, I think encode an entry, decode meta, decode payload, they all belong to the entry's behaviors. So rebuilding parse meta func can make code more readable.