### PR TITLE
docs: fix typo

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -68,7 +68,7 @@ https://www.bilibili.com/video/BV1T34y1x7AS/
      - [LRem](#lrem)
      - [LRemByIndex](#lrembyindex)
      - [LSet](#lset)    
-     - [Ltrim](#ltrim)
+     - [LTrim](#LTrim)
      - [LSize](#lsize)      
      - [LKeys](#lkeys)
    - [Set](#set)
@@ -892,7 +892,7 @@ if err := db.Update(
 }
 ```
 
-##### Ltrim 
+##### LTrim 
 
 修剪一个已存在的 list，这样 list 就会只包含指定范围的指定元素。start 和 stop 都是由0开始计数的， 这里的 0 是列表里的第一个元素（表头），1 是第二个元素，以此类推。
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It supports fully serializable transactions and many data structures such as lis
         - [LRem](#lrem)
         - [LRemByIndex](#lrembyindex)
         - [LSet](#lset)
-        - [Ltrim](#ltrim)
+        - [LTrim](#LTrim)
         - [LSize](#lsize)
         - [LKeys](#lkeys)
       - [Set](#set)
@@ -879,7 +879,7 @@ if err := db.Update(
 }
 ```
 
-##### Ltrim 
+##### LTrim 
 
 Trims an existing list so that it will contain only the specified range of elements specified.
 The offsets start and stop are zero-based indexes 0 being the first element of the list (the head of the list),


### PR DESCRIPTION
Document title is consistent with API