### PR TITLE
feat: add meta file to DB system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,9 @@
 * [Refactor] use size constant value (#204) @elliotchenzichang
 * [Chore] add iterator example (#209) @xujiajun
 * [Chore] remove option StartFileLoadingMode (#218) @xujiajun
+
+## v0.11.1（2022-11-13）
+* [Bug Fix] avoid nil of it.current (#233) @mindon
+* [Bug Fix] it.current may be nil when options.Reverse is false (#234) @xujiajun
+* [Refactor] changing the lock to be one of property of the structure can make the code more readable.(#228) @elliotchenzichang
+* [New Feature] add buffer size of recovery reader as param (#230) @elliotchenzichang

--- a/datafile.go
+++ b/datafile.go
@@ -36,6 +36,8 @@ const (
 
 	// DataEntryHeaderSize returns the entry header size
 	DataEntryHeaderSize = 42
+
+	MetaSuffix = ".json"
 )
 
 // DataFile records about data file information.

--- a/datafile.go
+++ b/datafile.go
@@ -37,7 +37,7 @@ const (
 	// DataEntryHeaderSize returns the entry header size
 	DataEntryHeaderSize = 42
 
-	MetaSuffix = ".json"
+	MetaFileName = "meta.json"
 )
 
 // DataFile records about data file information.

--- a/db.go
+++ b/db.go
@@ -450,9 +450,16 @@ func (db *DB) Close() error {
 		return err
 	}
 
+	err = db.MetaFile.rwManager.Release()
+	if err != nil {
+		return err
+	}
+
 	db.ActiveFile = nil
 
 	db.BPTreeIdx = nil
+
+	db.MetaFile = nil
 
 	err = db.fm.close()
 
@@ -477,12 +484,11 @@ func (db *DB) setActiveFile() (err error) {
 }
 
 func (db *DB) setMetaFile() (err error) {
-	filepath := db.getMetaJsonPath(db.MaxFileID)
-	db.MetaFile, err = db.fm.getDataFile(filepath, 1)
+	path := db.getMetaJsonPath()
+	db.MetaFile, err = db.fm.getDataFile(path, 1)
 	if err != nil {
 		return
 	}
-	db.MetaFile.fileID = db.MaxFileID
 	return nil
 }
 
@@ -1031,9 +1037,9 @@ func (db *DB) getDataPath(fID int64) string {
 	return db.opt.Dir + separator + strconv2.Int64ToStr(fID) + DataSuffix
 }
 
-func (db *DB) getMetaJsonPath(fID int64) string {
+func (db *DB) getMetaJsonPath() string {
 	separator := string(filepath.Separator)
-	return db.opt.Dir + separator + strconv2.Int64ToStr(fID) + MetaSuffix
+	return db.opt.Dir + separator + MetaFileName
 }
 
 func (db *DB) getMetaPath() string {

--- a/db_test.go
+++ b/db_test.go
@@ -59,6 +59,9 @@ func InitOpt(fileDir string, isRemoveFiles bool) {
 func TestDB_MetaJsonFile(t *testing.T) {
 	InitOpt("", true)
 	db, err = Open(opt)
+	if err != nil {
+		t.Error(err)
+	}
 	defer db.Close()
 
 	require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -65,7 +65,7 @@ func TestDB_MetaJsonFile(t *testing.T) {
 
 	bucket := "bucket1"
 
-	for i := 1; i < 1000; i++ {
+	for i := 1; i < 10; i++ {
 		key := []byte(fmt.Sprintf("key%d", i))
 
 		val := []byte(fmt.Sprintf("val%d", i))

--- a/db_test.go
+++ b/db_test.go
@@ -51,9 +51,31 @@ func InitOpt(fileDir string, isRemoveFiles bool) {
 
 	opt = DefaultOptions
 	opt.Dir = fileDir
-	opt.SegmentSize = 8 * 1024
+	opt.SegmentSize = 1024 * 8
 	opt.CleanFdsCacheThreshold = 0.5
 	opt.MaxFdNumsInCache = 1024
+}
+
+func TestDB_MetaJsonFile(t *testing.T) {
+	InitOpt("", true)
+	db, err = Open(opt)
+	defer db.Close()
+
+	require.NoError(t, err)
+
+	bucket := "bucket1"
+
+	for i := 1; i < 1000; i++ {
+		key := []byte(fmt.Sprintf("key%d", i))
+
+		val := []byte(fmt.Sprintf("val%d", i))
+		//put
+		err = db.Update(
+			func(tx *Tx) error {
+				return tx.Put(bucket, key, val, Persistent)
+			})
+	}
+
 }
 
 func TestDB_Basic(t *testing.T) {

--- a/entry.go
+++ b/entry.go
@@ -51,6 +51,13 @@ type (
 		Status     uint16 // committed / uncommitted
 		Ds         uint16 // data structure
 	}
+
+	Desc struct {
+		MinTs      int64 `json:"minTs"`
+		MaxTs      int64 `json:"maxTs"`
+		EntryCount int   `json:"entryCount"`
+		EntryBytes int64 `json:"entryBytes"`
+	}
 )
 
 // Size returns the size of the entry.

--- a/entry.go
+++ b/entry.go
@@ -53,10 +53,11 @@ type (
 	}
 
 	Desc struct {
-		MinTs      int64 `json:"minTs"`
-		MaxTs      int64 `json:"maxTs"`
-		EntryCount int   `json:"entryCount"`
-		EntryBytes int64 `json:"entryBytes"`
+		FileName   string `json:"fileName"`
+		MinTs      int64  `json:"minTs"`
+		MaxTs      int64  `json:"maxTs"`
+		EntryCount int    `json:"entryCount"`
+		EntryBytes int64  `json:"entryBytes"`
 	}
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cespare/xxhash/v2 v2.1.2
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
 	github.com/xujiajun/gorouter v1.2.0
 	github.com/xujiajun/mmap-go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/xujiajun/gorouter v1.2.0 h1:aPKfkzLHxPYRgr+irEE00SEOf78LHnxH/v4m8QiV5
 github.com/xujiajun/gorouter v1.2.0/go.mod h1:yJrIta+bTNpBM/2UT8hLOaEAFckO+m/qmR3luMIQygM=
 github.com/xujiajun/mmap-go v1.0.1 h1:7Se7ss1fLPPRW+ePgqGpCkfGIZzJV6JPq9Wq9iv/WHc=
 github.com/xujiajun/mmap-go v1.0.1/go.mod h1:CNN6Sw4SL69Sui00p0zEzcZKbt+5HtEnYUsc6BKKRMg=
-github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b h1:jKG9OiL4T4xQN3IUrhUpc1tG+HfDXppkgVcrAiiaI/0=
-github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b/go.mod h1:AZd87GYJlUzl82Yab2kTjx1EyXSQCAfZDhpTo1SQC4k=
 github.com/xujiajun/utils v0.0.0-20220904132955-5f7c5b914235 h1:w0si+uee0iAaCJO9q86T6yrhdadgcsoNuh47LrUykzg=
 github.com/xujiajun/utils v0.0.0-20220904132955-5f7c5b914235/go.mod h1:MR4+0R6A9NS5IABnIM3384FfOq8QFVnm7WDrBOhIaMU=
 golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
The user can clearly see the current file data, and can easily do some operations, such as the user can clear the old data file.
```go
zhaozhenhang@zhaozhenhangdeMacBook-Pro nutsdbtest % ls
0.dat		1.dat		2.dat		3.dat		4.dat		5.dat		6.dat		7.dat		meta.json
zhaozhenhang@zhaozhenhangdeMacBook-Pro nutsdbtest % cat meta.json
{
     "fileName": "0.dat",
     "minTs": 1670947210,
     "maxTs": 1670947213,
     "entryCount": 138,
     "entryBytes": 8202
}
{
     "fileName": "1.dat",
     "minTs": 1670947213,
     "maxTs": 1670947216,
     "entryCount": 134,
     "entryBytes": 8174
}
{
     "fileName": "2.dat",
     "minTs": 1670947216,
     "maxTs": 1670947218,
     "entryCount": 134,
     "entryBytes": 8174
}
{
     "fileName": "3.dat",
     "minTs": 1670947218,
     "maxTs": 1670947220,
     "entryCount": 134,
     "entryBytes": 8174
}
{
     "fileName": "4.dat",
     "minTs": 1670947220,
     "maxTs": 1670947222,
     "entryCount": 134,
     "entryBytes": 8174
}
{
     "fileName": "5.dat",
     "minTs": 1670947222,
     "maxTs": 1670947225,
     "entryCount": 134,
     "entryBytes": 8174
}
{
     "fileName": "6.dat",
     "minTs": 1670947225,
     "maxTs": 1670947227,
     "entryCount": 134,
     "entryBytes": 8174
}
```