### PR TITLE
delete verify length logic

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -16,7 +16,6 @@ package nutsdb
 
 import (
 	"encoding/binary"
-	"errors"
 	"hash/crc32"
 )
 
@@ -121,9 +120,6 @@ func (e *Entry) GetCrc(buf []byte) uint32 {
 
 // ParsePayload means this function will parse a byte array to bucket, key, size of an entry
 func (e *Entry) ParsePayload(data []byte) error {
-	if e.Meta == nil || (e.Meta.BucketSize+e.Meta.KeySize+e.Meta.ValueSize != uint32(len(data))) {
-		return errors.New("data validation fail")
-	}
 	meta := e.Meta
 	bucketLowBound := 0
 	bucketHighBound := meta.BucketSize


### PR DESCRIPTION
I read the context of this function and found that we can delete this verify logic because we created the payload buffer via the sum of the length of the bucket, key, and value. So I think the result of this verification logic always is true.