### PR TITLE
Add test for `WriteNode` in `bptree.go`

### DIFF
--- a/bptree.go
+++ b/bptree.go
@@ -372,7 +372,7 @@ func ReadNode(filePath string, address int64) (bn *BinaryNode, err error) {
 	}
 	defer f.Close()
 
-	size := int64(unsafe.Sizeof(BinaryNode{}))
+	size := getBinaryNodeSize()
 
 	data := make([]byte, size)
 	_, err = f.Seek(address, 0)

--- a/bptree_test.go
+++ b/bptree_test.go
@@ -528,7 +528,7 @@ func TestBPTree_WriteNode(t *testing.T) {
 			key := []byte("key_001")
 			tree.Filepath = testFilename
 
-			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 644)
+			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 0644)
 			assert.NoError(t, err)
 
 			node := tree.FindLeaf(key)

--- a/bptree_test.go
+++ b/bptree_test.go
@@ -520,10 +520,10 @@ func TestBPTree_ToBinary(t *testing.T) {
 	})
 }
 
-func TestBPTree_WriteAndReadNode(t *testing.T) {
-	testFilename := "bptree_rw_test.bptidx"
+func TestBPTree_WriteNode(t *testing.T) {
+	testFilename := "bptree_write_test.bptidx"
 
-	t.Run("test write and read node", func(t *testing.T) {
+	t.Run("test write node", func(t *testing.T) {
 		withBPTree(t, func(t *testing.T, tree *BPTree) {
 			key := []byte("key_001")
 			tree.Filepath = testFilename
@@ -535,18 +535,9 @@ func TestBPTree_WriteAndReadNode(t *testing.T) {
 			num, err := tree.WriteNode(node, -1, false, fd)
 			assert.NoError(t, err)
 
-			bnNode := &BinaryNode{[7]int64{}, [9]int64{}, 1, 4, 0, -1}
 			bnByte, err := tree.ToBinary(node)
 			assert.NoError(t, err)
 			assert.Equal(t, num, len(bnByte))
-
-			bnExist, err := ReadNode(tree.Filepath, 0)
-			assert.NoError(t, err)
-			assert.Equal(t, bnNode, bnExist)
-
-			bnNotExist, err := ReadNode(tree.Filepath, 1)
-			assert.Error(t, err)
-			assert.Nil(t, bnNotExist)
 		})
 	})
 

--- a/bptree_test.go
+++ b/bptree_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -517,4 +518,58 @@ func TestBPTree_ToBinary(t *testing.T) {
 			assert.Equal(t, r, buf.Bytes())
 		})
 	})
+}
+
+func TestBPTree_WriteNode(t *testing.T) {
+	testFilename := "bptree_test_for_rw"
+
+	t.Run("test write node", func(t *testing.T) {
+		withBPTree(t, func(t *testing.T, tree *BPTree) {
+			key := []byte("key_001")
+			tree.Filepath = testFilename
+
+			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 0644)
+			assert.NoError(t, err)
+
+			node := tree.FindLeaf(key)
+			num, err := tree.WriteNode(node, -1, false, fd)
+			assert.NoError(t, err)
+
+			bn, err := tree.ToBinary(node)
+			assert.NoError(t, err)
+			assert.Equal(t, num, len(bn))
+		})
+	})
+
+	// remove the test file
+	_ = os.Remove(testFilename)
+}
+
+func TestReadNode(t *testing.T) {
+	testFilename := "bptree_test_for_rw"
+
+	t.Run("test read node", func(t *testing.T) {
+		withBPTree(t, func(t *testing.T, tree *BPTree) {
+			key := []byte("key_001")
+			tree.Filepath = testFilename
+
+			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 0644)
+			assert.NoError(t, err)
+
+			node := tree.FindLeaf(key)
+			_, err = tree.WriteNode(node, -1, false, fd)
+			assert.NoError(t, err)
+
+			bn := &BinaryNode{[7]int64{}, [9]int64{}, 1, 4, 0, -1}
+			bnExist, err := ReadNode(tree.Filepath, 0)
+			assert.NoError(t, err)
+			assert.Equal(t, bn, bnExist)
+
+			bnNotExist, err := ReadNode(tree.Filepath, 1)
+			assert.Error(t, err)
+			assert.Nil(t, bnNotExist)
+		})
+	})
+
+	_ = os.Remove(testFilename)
 }

--- a/bptree_test.go
+++ b/bptree_test.go
@@ -520,50 +520,29 @@ func TestBPTree_ToBinary(t *testing.T) {
 	})
 }
 
-func TestBPTree_WriteNode(t *testing.T) {
-	testFilename := "bptree_test_for_rw"
+func TestBPTree_WriteAndReadNode(t *testing.T) {
+	testFilename := "bptree_rw_test.bptidx"
 
-	t.Run("test write node", func(t *testing.T) {
+	t.Run("test write and read node", func(t *testing.T) {
 		withBPTree(t, func(t *testing.T, tree *BPTree) {
 			key := []byte("key_001")
 			tree.Filepath = testFilename
 
-			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 0644)
+			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 644)
 			assert.NoError(t, err)
 
 			node := tree.FindLeaf(key)
 			num, err := tree.WriteNode(node, -1, false, fd)
 			assert.NoError(t, err)
 
-			bn, err := tree.ToBinary(node)
+			bnNode := &BinaryNode{[7]int64{}, [9]int64{}, 1, 4, 0, -1}
+			bnByte, err := tree.ToBinary(node)
 			assert.NoError(t, err)
-			assert.Equal(t, num, len(bn))
-		})
-	})
+			assert.Equal(t, num, len(bnByte))
 
-	// remove the test file
-	_ = os.Remove(testFilename)
-}
-
-func TestReadNode(t *testing.T) {
-	testFilename := "bptree_test_for_rw"
-
-	t.Run("test read node", func(t *testing.T) {
-		withBPTree(t, func(t *testing.T, tree *BPTree) {
-			key := []byte("key_001")
-			tree.Filepath = testFilename
-
-			fd, err := os.OpenFile(tree.Filepath, os.O_CREATE|os.O_RDWR, 0644)
-			assert.NoError(t, err)
-
-			node := tree.FindLeaf(key)
-			_, err = tree.WriteNode(node, -1, false, fd)
-			assert.NoError(t, err)
-
-			bn := &BinaryNode{[7]int64{}, [9]int64{}, 1, 4, 0, -1}
 			bnExist, err := ReadNode(tree.Filepath, 0)
 			assert.NoError(t, err)
-			assert.Equal(t, bn, bnExist)
+			assert.Equal(t, bnNode, bnExist)
 
 			bnNotExist, err := ReadNode(tree.Filepath, 1)
 			assert.Error(t, err)
@@ -571,5 +550,6 @@ func TestReadNode(t *testing.T) {
 		})
 	})
 
+	// remove the test file
 	_ = os.Remove(testFilename)
 }


### PR DESCRIPTION
- Add test for `WriteNode` in `bptree.go`, refer to issues #238 
- Change the code in `bptree.go`, by considering the consistency of code