### PR TITLE
issue #306 - added a MAX_SIZE const that fits 32 and 64bit arch

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,0 +1,21 @@
+//go:build !386 && !arm
+
+// Copyright 2019 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import "math"
+
+const MAX_SIZE = math.MaxInt32

--- a/const_32bits.go
+++ b/const_32bits.go
@@ -1,0 +1,21 @@
+//go:build 386 || arm
+
+// Copyright 2019 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import "math"
+
+const MAX_SIZE = math.MaxInt32

--- a/tx.go
+++ b/tx.go
@@ -17,7 +17,6 @@ package nutsdb
 import (
 	"bytes"
 	"errors"
-	"math"
 	"os"
 	"strings"
 	"sync"
@@ -179,7 +178,7 @@ func (tx *Tx) Commit() error {
 			return ErrDataSizeExceed
 		}
 
-		if len(entry.Meta.Bucket) > math.MaxUint32 || len(entry.Key) > math.MaxUint32 || len(entry.Value) > math.MaxUint32 {
+		if len(entry.Meta.Bucket) > MAX_SIZE || len(entry.Key) > MAX_SIZE || len(entry.Value) > MAX_SIZE {
 			return ErrDataSizeExceed
 		}
 


### PR DESCRIPTION
relates to  https://github.com/nutsdb/nutsdb/issues/306

Introduces a new MAX_SIZE const that depends on the target architecture -> math.MaxInt32 for 32bit, math.MaxUInt32 for 64 bit