### PR TITLE
chore: remove element in cache on closing fd manager

### DIFF
--- a/fd_manager.go
+++ b/fd_manager.go
@@ -205,6 +205,8 @@ func (fdm *fdManager) closeByPath(path string) error {
 	if !ok {
 		return nil
 	}
+	delete(fdm.cache, path)
+
 	fdm.fdList.removeNode(fdInfo)
 	return fdInfo.fd.Close()
 }


### PR DESCRIPTION
I believe removing the element in cache when close `fdManager` will make the process more elegant.