### PR TITLE
fix: deadlock caused by error

### DIFF
--- a/db.go
+++ b/db.go
@@ -986,7 +986,11 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 
 	if err = fn(tx); err == nil {
 		err = tx.Commit()
+	} else {
+		errRollback := tx.Rollback()
+		err = fmt.Errorf("%v. Rollback err: %v", err, errRollback)
 	}
+
 	return err
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -1167,12 +1167,18 @@ func TestErrWhenBuildListIdx(t *testing.T) {
 	}
 }
 
-func TestDB_ReadErrThenWrite(t *testing.T) {
+func TestDB_ErrThenReadWrite(t *testing.T) {
 	InitOpt("", true)
 	db, err = Open(opt)
 	require.NoError(t, err)
 
 	bucket := "testForDeadLock"
+	err = db.View(
+		func(tx *Tx) error {
+			return fmt.Errorf("err happened")
+		})
+	require.NotNil(t, err)
+
 	err = db.View(
 		func(tx *Tx) error {
 			key := []byte("key1")

--- a/db_test.go
+++ b/db_test.go
@@ -1173,7 +1173,7 @@ func TestDB_ReadErrThenWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	bucket := "testForDeadLock"
-	db.View(
+	err = db.View(
 		func(tx *Tx) error {
 			key := []byte("key1")
 			_, err := tx.Get(bucket, key)
@@ -1183,15 +1183,17 @@ func TestDB_ReadErrThenWrite(t *testing.T) {
 
 			return nil
 		})
+	require.NotNil(t, err)
 
 	notice := make(chan struct{})
 	go func() {
-		db.Update(
+		err = db.Update(
 			func(tx *Tx) error {
 				notice <- struct{}{}
 
 				return nil
 			})
+		require.NoError(t, err)
 	}()
 
 	select {


### PR DESCRIPTION
Fix the issue that deadlock may occur when an error occurs in `db.managed`.  
TODO: The `option` can be provided to let the user set the `errHandle Func`. When an error occurs in `db.managed`, the `errHandle Func` will be executed.

