### PR TITLE
feature: make all objects set to nil after the user calls the close f…

### DIFF
--- a/options.go
+++ b/options.go
@@ -60,6 +60,9 @@ type Options struct {
 
 	// BufferSizeOfRecovery represents the buffer size of recoveryReader buffer Size
 	BufferSizeOfRecovery int
+
+	// CcWhenClose represent initiative GC when calling db.Close()
+	GCWhenClose bool
 }
 
 const (
@@ -139,5 +142,11 @@ func WithCleanFdsCacheThreshold(threshold float64) Option {
 func WithBufferSizeOfRecovery(size int) Option {
 	return func(opt *Options) {
 		opt.BufferSizeOfRecovery = size
+	}
+}
+
+func WithGCWhenClose(enable bool) Option {
+	return func(opt *Options) {
+		opt.GCWhenClose = enable
 	}
 }


### PR DESCRIPTION
Fixes #347 
3. Set all obj in the db instance to nil when the user calls the close() method and add GC options in DB which determine whether trigger GC when the user calls the close() method.