### PR TITLE
refactor: refactoring the initialization way of the MetaData

### DIFF
--- a/bptree_test.go
+++ b/bptree_test.go
@@ -41,7 +41,7 @@ func withBPTree(t *testing.T, fn func(t *testing.T, tree *BPTree)) {
 		key := []byte(fmt.Sprintf(keyFormat, i))
 		val := []byte(fmt.Sprintf(valFormat, i))
 
-		meta := &MetaData{Flag: DataSetFlag}
+		meta := NewMetaData().WithFlag(DataSetFlag)
 		err := tree.Insert(key,
 			NewEntry().WithKey(key).WithValue(val),
 			NewHint().WithKey(key).WithMeta(meta),
@@ -54,9 +54,7 @@ func withBPTree(t *testing.T, fn func(t *testing.T, tree *BPTree)) {
 
 func setup(t *testing.T, limit int) {
 	tree = NewTree()
-	meta := &MetaData{
-		Flag: DataSetFlag,
-	}
+	meta := NewMetaData().WithFlag(DataSetFlag)
 	for i := 0; i < 100; i++ {
 		key := []byte("key_" + fmt.Sprintf("%03d", i))
 		val := []byte("val_" + fmt.Sprintf("%03d", i))
@@ -172,9 +170,7 @@ func TestBPTree_PrefixScan(t *testing.T) {
 
 	t.Run("prefix scan after insert a new record", func(t *testing.T) {
 		withBPTree(t, func(t *testing.T, tree *BPTree) {
-			meta := &MetaData{
-				Flag: DataSetFlag,
-			}
+			meta := NewMetaData().WithFlag(DataSetFlag)
 			for i := 0; i <= 100; i++ {
 				key := []byte("name_" + fmt.Sprintf("%03d", i))
 				val := []byte("val_" + fmt.Sprintf("%03d", i))
@@ -270,9 +266,7 @@ func TestBPTree_PrefixSearchScan(t *testing.T) {
 		t.Errorf("err prefix search Scan. Regexp not found")
 	}
 
-	meta := &MetaData{
-		Flag: DataSetFlag,
-	}
+	meta := NewMetaData().WithFlag(DataSetFlag)
 	for i := 0; i <= 100; i++ {
 		key := []byte("name_" + fmt.Sprintf("%03d", i))
 		val := []byte("val_" + fmt.Sprintf("%03d", i))
@@ -338,11 +332,7 @@ func TestRecordExpired(t *testing.T) {
 	expiredTime := uint64(time.Now().Add(-1 * time.Hour).Unix())
 
 	t.Run("test expired record", func(t *testing.T) {
-
-		meta := &MetaData{
-			Timestamp: expiredTime,
-			TTL:       10,
-		}
+		meta := NewMetaData().WithTimeStamp(expiredTime).WithTTL(10)
 		H := NewHint().WithMeta(meta)
 		record := NewRecord().WithHint(H)
 
@@ -350,10 +340,7 @@ func TestRecordExpired(t *testing.T) {
 	})
 
 	t.Run("test persistent record", func(t *testing.T) {
-		meta := &MetaData{
-			Timestamp: expiredTime,
-			TTL:       Persistent,
-		}
+		meta := NewMetaData().WithTimeStamp(expiredTime).WithTTL(Persistent)
 
 		H := NewHint().WithMeta(meta)
 		record := NewRecord().WithHint(H)
@@ -365,9 +352,7 @@ func TestBPTree_Update(t *testing.T) {
 	limit := 10
 	setup(t, limit)
 
-	meta := &MetaData{
-		Flag: DataSetFlag,
-	}
+	meta := NewMetaData().WithFlag(DataSetFlag)
 	for i := 0; i <= 100; i++ {
 		key := []byte("key_" + fmt.Sprintf("%03d", i))
 		val := []byte("val_modify" + fmt.Sprintf("%03d", i))
@@ -382,9 +367,7 @@ func TestBPTree_Update(t *testing.T) {
 	}
 
 	expected := Records{}
-	meta = &MetaData{
-		Flag: DataSetFlag,
-	}
+	meta = NewMetaData().WithFlag(DataSetFlag)
 	for i := 0; i <= limit; i++ {
 		key := []byte("key_" + fmt.Sprintf("%03d", i))
 		val := []byte("val_modify" + fmt.Sprintf("%03d", i))
@@ -403,9 +386,7 @@ func TestBPTree_Update(t *testing.T) {
 	}
 
 	// delete
-	meta = &MetaData{
-		Flag: DataDeleteFlag,
-	}
+	meta = NewMetaData().WithFlag(DataDeleteFlag)
 	for i := 1; i <= limit; i++ {
 		key := []byte("key_" + fmt.Sprintf("%03d", i))
 		err := tree.Insert(
@@ -426,9 +407,7 @@ func TestBPTree_Update(t *testing.T) {
 	}
 
 	key := []byte("key_001")
-	meta = &MetaData{
-		Flag: DataSetFlag,
-	}
+	meta = NewMetaData().WithFlag(DataSetFlag)
 	err = tree.Insert(
 		key,
 		NewEntry().WithKey(key),

--- a/datafile_test.go
+++ b/datafile_test.go
@@ -32,14 +32,9 @@ func init() {
 		Key:    []byte("key_0001"),
 		Value:  []byte("val_0001"),
 		Bucket: []byte("test_DataFile"),
-		Meta: &MetaData{
-			KeySize:    uint32(len("key_0001")),
-			ValueSize:  uint32(len("val_0001")),
-			Timestamp:  1547707905,
-			TTL:        Persistent,
-			BucketSize: uint32(len("test_datafile")),
-			Flag:       DataSetFlag,
-		},
+		Meta: NewMetaData().WithKeySize(uint32(len("key_0001"))).
+			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).
+			WithBucketSize(uint32(len("test_datafile"))).WithFlag(DataSetFlag),
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -621,7 +621,7 @@ func (db *DB) parseDataFiles(dataFileIds []int) (unconfirmedRecords []*Record, c
 
 				if entry.Meta.Status == Committed {
 					committedTxIds[entry.Meta.TxID] = struct{}{}
-					meta := &MetaData{Flag: DataSetFlag}
+					meta := NewMetaData().WithFlag(DataSetFlag)
 					h := NewHint().WithMeta(meta)
 					err := db.ActiveCommittedTxIdsIdx.Insert(entry.GetTxIDBytes(), nil, h, CountFlagEnabled)
 					if err != nil {

--- a/entry.go
+++ b/entry.go
@@ -154,19 +154,12 @@ func (e *Entry) checkPayloadSize(size int64) error {
 
 // ParseMeta parse meta object to entry
 func (e *Entry) ParseMeta(buf []byte) error {
-	meta := &MetaData{
-		Crc:        binary.LittleEndian.Uint32(buf[0:4]),
-		Timestamp:  binary.LittleEndian.Uint64(buf[4:12]),
-		KeySize:    binary.LittleEndian.Uint32(buf[12:16]),
-		ValueSize:  binary.LittleEndian.Uint32(buf[16:20]),
-		Flag:       binary.LittleEndian.Uint16(buf[20:22]),
-		TTL:        binary.LittleEndian.Uint32(buf[22:26]),
-		BucketSize: binary.LittleEndian.Uint32(buf[26:30]),
-		Status:     binary.LittleEndian.Uint16(buf[30:32]),
-		Ds:         binary.LittleEndian.Uint16(buf[32:34]),
-		TxID:       binary.LittleEndian.Uint64(buf[34:42]),
-	}
-	e.Meta = meta
+	e.Meta = NewMetaData().WithCrc(binary.LittleEndian.Uint32(buf[0:4])).
+		WithTimeStamp(binary.LittleEndian.Uint64(buf[4:12])).WithKeySize(binary.LittleEndian.Uint32(buf[12:16])).
+		WithValueSize(binary.LittleEndian.Uint32(buf[16:20])).WithFlag(binary.LittleEndian.Uint16(buf[20:22])).
+		WithTTL(binary.LittleEndian.Uint32(buf[22:26])).WithBucketSize(binary.LittleEndian.Uint32(buf[26:30])).
+		WithStatus(binary.LittleEndian.Uint16(buf[30:32])).WithDs(binary.LittleEndian.Uint16(buf[32:34])).
+		WithTxID(binary.LittleEndian.Uint64(buf[34:42]))
 	return nil
 }
 
@@ -270,4 +263,58 @@ func (e *Entry) GetBucketString() string {
 // GetTxIDBytes return the bytes of TxID
 func (e *Entry) GetTxIDBytes() []byte {
 	return []byte(strconv2.Int64ToStr(int64(e.Meta.TxID)))
+}
+
+func NewMetaData() *MetaData {
+	return new(MetaData)
+}
+
+func (meta *MetaData) WithKeySize(keySize uint32) *MetaData {
+	meta.KeySize = keySize
+	return meta
+}
+
+func (meta *MetaData) WithValueSize(valueSize uint32) *MetaData {
+	meta.ValueSize = valueSize
+	return meta
+}
+
+func (meta *MetaData) WithTimeStamp(timestamp uint64) *MetaData {
+	meta.Timestamp = timestamp
+	return meta
+}
+
+func (meta *MetaData) WithTTL(ttl uint32) *MetaData {
+	meta.TTL = ttl
+	return meta
+}
+
+func (meta *MetaData) WithFlag(flag uint16) *MetaData {
+	meta.Flag = flag
+	return meta
+}
+
+func (meta *MetaData) WithBucketSize(bucketSize uint32) *MetaData {
+	meta.BucketSize = bucketSize
+	return meta
+}
+
+func (meta *MetaData) WithTxID(txID uint64) *MetaData {
+	meta.TxID = txID
+	return meta
+}
+
+func (meta *MetaData) WithStatus(status uint16) *MetaData {
+	meta.Status = status
+	return meta
+}
+
+func (meta *MetaData) WithDs(ds uint16) *MetaData {
+	meta.Ds = ds
+	return meta
+}
+
+func (meta *MetaData) WithCrc(crc uint32) *MetaData {
+	meta.Crc = crc
+	return meta
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -34,14 +34,9 @@ func (suite *EntryTestSuite) SetupSuite() {
 		Key:    []byte("key_0001"),
 		Value:  []byte("val_0001"),
 		Bucket: []byte("test_entry"),
-		Meta: &MetaData{
-			KeySize:    uint32(len("key_0001")),
-			ValueSize:  uint32(len("val_0001")),
-			Timestamp:  1547707905,
-			TTL:        Persistent,
-			BucketSize: uint32(len("test_entry")),
-			Flag:       DataSetFlag,
-		},
+		Meta: NewMetaData().WithKeySize(uint32(len("key_0001"))).
+			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).
+			WithBucketSize(uint32(len("test_entry"))).WithFlag(DataSetFlag),
 	}
 	suite.expectedEncode = []byte{48, 176, 185, 16, 1, 38, 64, 92, 0, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 101, 115, 116, 95, 101, 110, 116, 114, 121, 107, 101, 121, 95, 48, 48, 48, 49, 118, 97, 108, 95, 48, 48, 48, 49}
 }

--- a/inmemory/kv.go
+++ b/inmemory/kv.go
@@ -136,33 +136,16 @@ func put(shardDB *ShardDB, bucket string, key, value []byte, ttl uint32, flag ui
 	valueSize := uint32(len(value))
 	timestamp := uint64(time.Now().Unix())
 	bucketSize := uint32(len(bucket))
+	meta := nutsdb.NewMetaData().WithTimeStamp(timestamp).WithKeySize(keySize).WithValueSize(valueSize).WithFlag(flag).WithTTL(ttl).
+		WithBucketSize(bucketSize).WithStatus(nutsdb.Committed).WithDs(nutsdb.DataStructureBPTree)
 	err = shardDB.BPTreeIdx[bucket].Insert(key, &nutsdb.Entry{
 		Key:    key,
 		Value:  value,
 		Bucket: []byte(bucket),
-
-		Meta: &nutsdb.MetaData{
-			KeySize:    keySize,
-			ValueSize:  valueSize,
-			Timestamp:  timestamp,
-			Flag:       flag,
-			TTL:        ttl,
-			BucketSize: bucketSize,
-			Status:     nutsdb.Committed,
-			Ds:         nutsdb.DataStructureBPTree,
-		},
+		Meta:   meta,
 	}, &nutsdb.Hint{
-		Key: key,
-		Meta: &nutsdb.MetaData{
-			KeySize:    keySize,
-			ValueSize:  valueSize,
-			Timestamp:  timestamp,
-			Flag:       flag,
-			TTL:        ttl,
-			BucketSize: bucketSize,
-			Status:     nutsdb.Committed,
-			Ds:         nutsdb.DataStructureBPTree,
-		},
+		Key:  key,
+		Meta: meta,
 	}, nutsdb.CountFlagEnabled)
 	return
 }

--- a/inmemory/kv.go
+++ b/inmemory/kv.go
@@ -138,14 +138,8 @@ func put(shardDB *ShardDB, bucket string, key, value []byte, ttl uint32, flag ui
 	bucketSize := uint32(len(bucket))
 	meta := nutsdb.NewMetaData().WithTimeStamp(timestamp).WithKeySize(keySize).WithValueSize(valueSize).WithFlag(flag).WithTTL(ttl).
 		WithBucketSize(bucketSize).WithStatus(nutsdb.Committed).WithDs(nutsdb.DataStructureBPTree)
-	err = shardDB.BPTreeIdx[bucket].Insert(key, &nutsdb.Entry{
-		Key:    key,
-		Value:  value,
-		Bucket: []byte(bucket),
-		Meta:   meta,
-	}, &nutsdb.Hint{
-		Key:  key,
-		Meta: meta,
-	}, nutsdb.CountFlagEnabled)
+	entry := nutsdb.NewEntry().WithKey(key).WithValue(value).WithBucket([]byte(bucket)).WithMeta(meta)
+	hint := nutsdb.NewHint().WithKey(key).WithMeta(meta)
+	err = shardDB.BPTreeIdx[bucket].Insert(key, entry, hint, nutsdb.CountFlagEnabled)
 	return
 }

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -12,14 +12,9 @@ func Test_readEntry(t *testing.T) {
 
 	fd, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_RDWR, os.ModePerm)
 	require.NoError(t, err)
-	meta := &MetaData{
-		KeySize:    uint32(len("key")),
-		ValueSize:  uint32(len("val")),
-		Timestamp:  1547707905,
-		TTL:        Persistent,
-		BucketSize: uint32(len("Test_readEntry")),
-		Flag:       DataSetFlag,
-	}
+	meta := NewMetaData().WithKeySize(uint32(len("key"))).
+		WithValueSize(uint32(len("val"))).WithTimeStamp(1547707905).WithTTL(Persistent).
+		WithBucketSize(uint32(len("Test_readEntry"))).WithFlag(DataSetFlag)
 
 	expect := NewEntry().WithKey([]byte("key")).WithMeta(meta).WithValue([]byte("val")).WithBucket([]byte("Test_readEntry"))
 

--- a/tx.go
+++ b/tx.go
@@ -354,7 +354,7 @@ func (tx *Tx) buildBucketMetaIdx(bucket string, key []byte, bucketMetaTemp Bucke
 func (tx *Tx) buildTxIDRootIdx(txID uint64, countFlag bool) error {
 	txIDStr := strconv2.IntToStr(int(txID))
 
-	meta := &MetaData{Flag: DataSetFlag}
+	meta := NewMetaData().WithFlag(DataSetFlag)
 	err := tx.db.ActiveCommittedTxIdsIdx.Insert([]byte(txIDStr), nil, NewHint().WithMeta(meta), countFlag)
 	if err != nil {
 		return err
@@ -704,17 +704,8 @@ func (tx *Tx) put(bucket string, key, value []byte, ttl uint32, flag uint16, tim
 		return ErrTxNotWritable
 	}
 
-	meta := &MetaData{
-		KeySize:    uint32(len(key)),
-		ValueSize:  uint32(len(value)),
-		Timestamp:  timestamp,
-		Flag:       flag,
-		TTL:        ttl,
-		BucketSize: uint32(len(bucket)),
-		Status:     UnCommitted,
-		Ds:         ds,
-		TxID:       tx.id,
-	}
+	meta := NewMetaData().WithTimeStamp(timestamp).WithKeySize(uint32(len(key))).WithValueSize(uint32(len(value))).WithFlag(flag).
+		WithTTL(ttl).WithBucketSize(uint32(len(bucket))).WithStatus(UnCommitted).WithDs(ds).WithTxID(tx.id)
 	e := NewEntry().WithKey(key).WithBucket([]byte(bucket)).WithMeta(meta).WithValue(value)
 
 	err := e.valid()


### PR DESCRIPTION
Using a chained call to initialize MetaData like NewMetaData.WithNewMetaData().WithKeySize(keySize).WithValueSize(valSize)...