### PR TITLE
pref: remove sync.Pool and prev allocate buffer for small tx

### DIFF
--- a/db.go
+++ b/db.go
@@ -15,6 +15,7 @@
 package nutsdb
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"github.com/gofrs/flock"
@@ -177,6 +178,7 @@ type (
 		isMerging               bool
 		fm                      *fileManager
 		flock                   *flock.Flock
+		commitBuffer            *bytes.Buffer
 	}
 
 	// Entries represents entries
@@ -204,6 +206,10 @@ func open(opt Options) (*DB, error) {
 		Index:                   NewIndex(),
 		fm:                      newFileManager(opt.RWMode, opt.MaxFdNumsInCache, opt.CleanFdsCacheThreshold),
 	}
+
+	commitBuffer := new(bytes.Buffer)
+	commitBuffer.Grow(int(db.opt.CommitBufferSize))
+	db.commitBuffer = commitBuffer
 
 	if ok := filesystem.PathIsExist(db.opt.Dir); !ok {
 		if err := os.MkdirAll(db.opt.Dir, os.ModePerm); err != nil {

--- a/options.go
+++ b/options.go
@@ -76,6 +76,9 @@ type Options struct {
 	// CcWhenClose represent initiative GC when calling db.Close()
 	GCWhenClose bool
 
+	// CommitBufferSize represent allocated memory for tx
+	CommitBufferSize int64
+
 	// ErrorHandler handles an error occurred during transaction.
 	// Example:
 	//     func triggerAlertError(err error) {
@@ -102,11 +105,12 @@ var defaultSegmentSize int64 = 256 * MB
 // DefaultOptions represents the default options.
 var DefaultOptions = func() Options {
 	return Options{
-		EntryIdxMode: HintKeyValAndRAMIdxMode,
-		SegmentSize:  defaultSegmentSize,
-		NodeNum:      1,
-		RWMode:       FileIO,
-		SyncEnable:   true,
+		EntryIdxMode:     HintKeyValAndRAMIdxMode,
+		SegmentSize:      defaultSegmentSize,
+		NodeNum:          1,
+		RWMode:           FileIO,
+		SyncEnable:       true,
+		CommitBufferSize: 4 * MB,
 	}
 }()
 
@@ -175,5 +179,11 @@ func WithGCWhenClose(enable bool) Option {
 func WithErrorHandler(errorHandler ErrorHandler) Option {
 	return func(opt *Options) {
 		opt.ErrorHandler = errorHandler
+	}
+}
+
+func WithCommitBufferSize(commitBufferSize int64) Option {
+	return func(opt *Options) {
+		opt.CommitBufferSize = commitBufferSize
 	}
 }

--- a/tx.go
+++ b/tx.go
@@ -198,6 +198,7 @@ func (tx *Tx) Commit() (err error) {
 	}
 
 	buff := tx.allocCommitBuffer()
+	defer tx.db.commitBuffer.Reset()
 
 	for i := 0; i < writesLen; i++ {
 		entry := tx.pendingWrites[i]
@@ -270,8 +271,6 @@ func (tx *Tx) Commit() (err error) {
 			tx.db.deleteBucket(DataStructureBPTree, bucket)
 		}
 	}
-
-	tx.db.commitBuffer.Reset()
 
 	tx.buildIdxes()
 


### PR DESCRIPTION
Based on issue #354, I have removed the usage of sync.pool. If it is a write transaction, it is always concurrency-safe. Instead, I have added a preallocated Buffer for reuse, and only transactions larger than this Buffer size will trigger a new Buffer.