### PR TITLE
feat: refactor list data structure by using doubly linked list and support HintKeyAndRAMIdxMode

### DIFF
--- a/examples/list/main.go
+++ b/examples/list/main.go
@@ -210,8 +210,7 @@ func testLRem() {
 	if err := db.Update(
 		func(tx *nutsdb.Tx) error {
 			key := []byte("myList")
-			num, err := tx.LRem(bucket, key, count, value)
-			fmt.Println("removed num: ", num)
+			err := tx.LRem(bucket, key, count, value)
 			return err
 		}); err != nil {
 		log.Fatal(err)
@@ -300,8 +299,7 @@ func testLRemByIndex() {
 	if err := db.Update(
 		func(tx *nutsdb.Tx) error {
 			key := []byte("myList")
-			removedNum, err := tx.LRemByIndex(bucket, key, 0)
-			fmt.Printf("removed num %d\n", removedNum)
+			err := tx.LRemByIndex(bucket, key, 0)
 			return err
 		}); err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/cespare/xxhash/v2 v2.1.2
+	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/gofrs/flock v0.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/index.go
+++ b/index.go
@@ -1,7 +1,6 @@
 package nutsdb
 
 import (
-	"github.com/nutsdb/nutsdb/ds/list"
 	"github.com/nutsdb/nutsdb/ds/set"
 	"github.com/nutsdb/nutsdb/ds/zset"
 )
@@ -16,7 +15,7 @@ type SetIdx map[string]*set.Set
 type SortedSetIdx map[string]*zset.SortedSet
 
 // ListIdx represents the list index
-type ListIdx map[string]*list.List
+type ListIdx map[string]*List
 
 type index struct {
 	list ListIdx
@@ -24,7 +23,7 @@ type index struct {
 
 func NewIndex() *index {
 	i := new(index)
-	i.list = map[string]*list.List{}
+	i.list = map[string]*List{}
 	return i
 }
 
@@ -33,16 +32,12 @@ func (i *index) existList(bucket string) bool {
 	return isExist
 }
 
-func (i *index) getList(bucket string) *list.List {
+func (i *index) getList(bucket string) *List {
 	l, isExist := i.list[bucket]
 	if isExist {
 		return l
 	}
-	l = &list.List{
-		Items:     map[string][][]byte{},
-		TTL:       map[string]uint32{},
-		TimeStamp: map[string]uint64{},
-	}
+	l = NewList()
 	i.list[bucket] = l
 	return l
 }
@@ -52,15 +47,11 @@ func (i *index) deleteList(bucket string) {
 }
 
 func (i *index) addList(bucket string) {
-	l := &list.List{
-		Items:     map[string][][]byte{},
-		TTL:       map[string]uint32{},
-		TimeStamp: map[string]uint64{},
-	}
+	l := NewList()
 	i.list[bucket] = l
 }
 
-func (i *index) rangeList(f func(l *list.List)) {
+func (i *index) rangeList(f func(l *List)) {
 	for _, l := range i.list {
 		f(l)
 	}

--- a/inmemory/shard.go
+++ b/inmemory/shard.go
@@ -15,26 +15,40 @@
 package inmemory
 
 import (
+	"github.com/nutsdb/nutsdb/ds/list"
+	"github.com/nutsdb/nutsdb/ds/set"
+	"github.com/nutsdb/nutsdb/ds/zset"
 	"sync"
 
 	"github.com/nutsdb/nutsdb"
 )
 
+type BPTreeIdx map[string]*nutsdb.BPTree
+
+// SetIdx represents the set index
+type SetIdx map[string]*set.Set
+
+// SortedSetIdx represents the sorted set index
+type SortedSetIdx map[string]*zset.SortedSet
+
+// ListIdx represents the list index
+type ListIdx map[string]*list.List
+
 type ShardDB struct {
-	BPTreeIdx    nutsdb.BPTreeIdx // Hint Index
-	SetIdx       nutsdb.SetIdx
-	SortedSetIdx nutsdb.SortedSetIdx
-	ListIdx      nutsdb.ListIdx
+	BPTreeIdx    BPTreeIdx // Hint Index
+	SetIdx       SetIdx
+	SortedSetIdx SortedSetIdx
+	ListIdx      ListIdx
 	mu           sync.RWMutex
 	KeyCount     int
 }
 
 func InitShardDB() *ShardDB {
 	return &ShardDB{
-		BPTreeIdx:    make(nutsdb.BPTreeIdx),
-		SetIdx:       make(nutsdb.SetIdx),
-		SortedSetIdx: make(nutsdb.SortedSetIdx),
-		ListIdx:      make(nutsdb.ListIdx),
+		BPTreeIdx:    make(BPTreeIdx),
+		SetIdx:       make(SetIdx),
+		SortedSetIdx: make(SortedSetIdx),
+		ListIdx:      make(ListIdx),
 		mu:           sync.RWMutex{},
 		KeyCount:     0,
 	}

--- a/list.go
+++ b/list.go
@@ -218,8 +218,8 @@ func (l *List) LSet(key string, index int, r *Record) error {
 	return nil
 }
 
-// Ltrim trim an existing list so that it will contain only the specified range of elements specified.
-func (l *List) Ltrim(key string, start, end int) error {
+// LTrim trim an existing list so that it will contain only the specified range of elements specified.
+func (l *List) LTrim(key string, start, end int) error {
 	if l.IsExpire(key) {
 		return ErrListNotFound
 	}
@@ -235,7 +235,9 @@ func (l *List) Ltrim(key string, start, end int) error {
 	list := l.Items[key]
 
 	list.Clear()
-	list.Add(items)
+	for _, item := range items {
+		list.Append(item)
+	}
 
 	return nil
 }
@@ -268,16 +270,19 @@ func (l *List) LRemByIndex(key string, indexes []int) error {
 	iterator := list.Iterator()
 	iterator.Begin()
 
-	items := make([]*Record, list.Size()-len(indexes))
+	items := make([]*Record, list.Size()-len(idxes))
 	i := 0
 	for iterator.Next() {
 		if _, ok := idxes[iterator.Index()]; !ok {
 			items[i] = iterator.Value().(*Record)
+			i++
 		}
 	}
 
 	list.Clear()
-	list.Add(items)
+	for _, item := range items {
+		list.Append(item)
+	}
 
 	return nil
 }

--- a/list.go
+++ b/list.go
@@ -1,0 +1,379 @@
+// Copyright 2023 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"bytes"
+	"errors"
+	dll "github.com/emirpasic/gods/lists/doublylinkedlist"
+	"time"
+)
+
+var (
+	// ErrListNotFound is returned when the list not found.
+	ErrListNotFound = errors.New("the list not found")
+
+	// ErrIndexOutOfRange is returned when use LSet function set index out of range.
+	ErrIndexOutOfRange = errors.New("index out of range")
+)
+
+// List represents the list.
+type List struct {
+	db        *DB
+	Items     map[string]*dll.List
+	TTL       map[string]uint32
+	TimeStamp map[string]uint64
+}
+
+func NewList() *List {
+	return &List{
+		Items:     make(map[string]*dll.List),
+		TTL:       make(map[string]uint32),
+		TimeStamp: make(map[string]uint64),
+	}
+}
+
+func (l *List) LPush(key string, r *Record) error {
+	return l.push(key, r, true)
+}
+
+func (l *List) RPush(key string, r *Record) error {
+	return l.push(key, r, false)
+}
+
+func (l *List) push(key string, r *Record, isLeft bool) error {
+	if l.IsExpire(key) {
+		return ErrListNotFound
+	}
+
+	list, ok := l.Items[key]
+	if !ok {
+		l.Items[key] = dll.New()
+		list = l.Items[key]
+	}
+
+	if isLeft {
+		list.Prepend(r)
+	} else {
+		list.Append(r)
+	}
+
+	return nil
+}
+
+func (l *List) LPop(key string) (*Record, error) {
+	r, err := l.LPeek(key)
+	if err != nil {
+		return nil, err
+	}
+
+	l.Items[key].Remove(0)
+	return r, nil
+}
+
+// RPop removes and returns the last element of the list stored at key.
+func (l *List) RPop(key string) (*Record, error) {
+	r, err := l.RPeek(key)
+	if err != nil {
+		return nil, err
+	}
+
+	l.Items[key].Remove(l.Items[key].Size() - 1)
+	return r, nil
+}
+
+func (l *List) LPeek(key string) (*Record, error) {
+	return l.peek(key, true)
+}
+
+func (l *List) RPeek(key string) (*Record, error) {
+	return l.peek(key, false)
+}
+
+func (l *List) peek(key string, isLeft bool) (*Record, error) {
+	if l.IsExpire(key) {
+		return nil, ErrListNotFound
+	}
+	list, ok := l.Items[key]
+	if !ok {
+		return nil, ErrListNotFound
+	}
+
+	if isLeft {
+		if r, ok := list.Get(0); ok {
+			return r.(*Record), nil
+		}
+	} else {
+		if r, ok := list.Get(l.Items[key].Size() - 1); ok {
+			return r.(*Record), nil
+		}
+	}
+
+	return nil, nil
+}
+
+// LRange returns the specified elements of the list stored at key [start,end]
+func (l *List) LRange(key string, start, end int) ([]*Record, error) {
+	size, err := l.Size(key)
+	if err != nil || size == 0 {
+		return nil, err
+	}
+
+	start, end, err = checkBounds(start, end, size)
+	if err != nil {
+		return nil, err
+	}
+
+	iterator := l.Items[key].Iterator()
+
+	for i := 0; i <= start; i++ {
+		iterator.Next()
+	}
+
+	items := make([]*Record, end-start+1)
+	for i := start; i <= end; i++ {
+		items[i-start] = iterator.Value().(*Record)
+		iterator.Next()
+	}
+
+	return items, nil
+}
+
+// LRem removes the first count occurrences of elements equal to value from the list stored at key.
+// The count argument influences the operation in the following ways:
+// count > 0: Remove elements equal to value moving from head to tail.
+// count < 0: Remove elements equal to value moving from tail to head.
+// count = 0: Remove all elements equal to value.
+func (l *List) LRem(key string, count int, value []byte) error {
+	if l.IsExpire(key) {
+		return ErrListNotFound
+	}
+
+	list, ok := l.Items[key]
+
+	if !ok {
+		return ErrListNotFound
+	}
+
+	iterator := list.Iterator()
+
+	if count >= 0 {
+		if count == 0 {
+			count = list.Size()
+		}
+		iterator.Begin()
+
+		for iterator.Next() && count > 0 {
+			r := iterator.Value().(*Record)
+
+			v, err := l.db.getValueByRecord(r)
+			if err != nil {
+				return err
+			}
+
+			if bytes.Equal(v, value) {
+				list.Remove(iterator.Index())
+				count--
+			}
+		}
+	}
+
+	if count < 0 {
+		iterator.End()
+
+		for iterator.Prev() && count < 0 {
+			r := iterator.Value().(*Record)
+
+			v, err := l.db.getValueByRecord(r)
+			if err != nil {
+				return err
+			}
+
+			if bytes.Equal(v, value) {
+				list.Remove(iterator.Index())
+				count++
+			}
+		}
+	}
+
+	return nil
+}
+
+// LSet sets the list element at index to value.
+func (l *List) LSet(key string, index int, r *Record) error {
+	if l.IsExpire(key) {
+		return ErrListNotFound
+	}
+	if _, ok := l.Items[key]; !ok {
+		return ErrListNotFound
+	}
+
+	size, _ := l.Size(key)
+	if index >= size || index < 0 {
+		return ErrIndexOutOfRange
+	}
+
+	l.Items[key].Set(index, r)
+
+	return nil
+}
+
+// Ltrim trim an existing list so that it will contain only the specified range of elements specified.
+func (l *List) Ltrim(key string, start, end int) error {
+	if l.IsExpire(key) {
+		return ErrListNotFound
+	}
+	if _, ok := l.Items[key]; !ok {
+		return ErrListNotFound
+	}
+
+	items, err := l.LRange(key, start, end)
+	if err != nil {
+		return err
+	}
+
+	list := l.Items[key]
+
+	list.Clear()
+	list.Add(items)
+
+	return nil
+}
+
+// LRemByIndex remove the list element at specified index
+func (l *List) LRemByIndex(key string, indexes []int) error {
+	if l.IsExpire(key) {
+		return ErrListNotFound
+	}
+
+	list := l.Items[key]
+
+	if list.Size() == 0 {
+		return nil
+	}
+
+	if len(indexes) == 1 {
+		list.Remove(indexes[0])
+		return nil
+	}
+
+	idxes := make(map[int]struct{})
+	for _, idx := range indexes {
+		if idx < 0 || idx >= list.Size() {
+			continue
+		}
+		idxes[idx] = struct{}{}
+	}
+
+	iterator := list.Iterator()
+	iterator.Begin()
+
+	items := make([]*Record, list.Size()-len(indexes))
+	i := 0
+	for iterator.Next() {
+		if _, ok := idxes[iterator.Index()]; !ok {
+			items[i] = iterator.Value().(*Record)
+		}
+	}
+
+	list.Clear()
+	list.Add(items)
+
+	return nil
+}
+
+func (l *List) IsExpire(key string) bool {
+	if l == nil {
+		return false
+	}
+
+	_, ok := l.TTL[key]
+	if !ok {
+		return false
+	}
+
+	now := time.Now().Unix()
+	timestamp := l.TimeStamp[key]
+	if l.TTL[key] > 0 && uint64(l.TTL[key])+timestamp > uint64(now) || l.TTL[key] == uint32(0) {
+		return false
+	}
+
+	delete(l.Items, key)
+	delete(l.TTL, key)
+	delete(l.TimeStamp, key)
+
+	return true
+}
+
+func (l *List) Size(key string) (int, error) {
+	if l.IsExpire(key) {
+		return 0, ErrListNotFound
+	}
+	if _, ok := l.Items[key]; !ok {
+		return 0, ErrListNotFound
+	}
+
+	return l.Items[key].Size(), nil
+}
+
+func (l *List) IsEmpty(key string) (bool, error) {
+	size, err := l.Size(key)
+	if err != nil || size > 0 {
+		return false, err
+	}
+	return true, nil
+}
+
+func (l *List) GetListTTL(key string) (uint32, error) {
+	if l.IsExpire(key) {
+		return 0, ErrListNotFound
+	}
+
+	ttl := l.TTL[key]
+	timestamp := l.TimeStamp[key]
+	if ttl == 0 || timestamp == 0 {
+		return 0, nil
+	}
+
+	now := time.Now().Unix()
+	remain := timestamp + uint64(ttl) - uint64(now)
+
+	return uint32(remain), nil
+
+}
+
+func checkBounds(start, end int, size int) (int, int, error) {
+	if start >= 0 && end < 0 {
+		end = size + end
+	}
+
+	if start < 0 && end > 0 {
+		start = size + start
+	}
+
+	if start < 0 && end < 0 {
+		start, end = size+start, size+end
+	}
+
+	if end >= size {
+		end = size - 1
+	}
+
+	if start > end {
+		return 0, 0, errors.New("start or end error")
+	}
+
+	return start, end, nil
+}

--- a/list.go
+++ b/list.go
@@ -284,9 +284,6 @@ func (l *List) LRemByIndex(key string, indexes []int) error {
 		if _, ok := idxes[iterator.Index()]; !ok {
 			items[i] = iterator.Value().(*Record)
 			i++
-			if i == len(idxes) {
-				break
-			}
 		}
 	}
 

--- a/list.go
+++ b/list.go
@@ -284,6 +284,9 @@ func (l *List) LRemByIndex(key string, indexes []int) error {
 		if _, ok := idxes[iterator.Index()]; !ok {
 			items[i] = iterator.Value().(*Record)
 			i++
+			if i == len(idxes) {
+				break
+			}
 		}
 	}
 

--- a/list.go
+++ b/list.go
@@ -154,7 +154,7 @@ func (l *List) LRange(key string, start, end int) ([]*Record, error) {
 // count > 0: Remove elements equal to value moving from head to tail.
 // count < 0: Remove elements equal to value moving from tail to head.
 // count = 0: Remove all elements equal to value.
-func (l *List) LRem(key string, count int, cmp func(r *Record) bool) error {
+func (l *List) LRem(key string, count int, cmp func(r *Record) (bool, error)) error {
 	if l.IsExpire(key) {
 		return ErrListNotFound
 	}
@@ -176,7 +176,11 @@ func (l *List) LRem(key string, count int, cmp func(r *Record) bool) error {
 		for iterator.Next() && count > 0 {
 			r := iterator.Value().(*Record)
 
-			if cmp(r) {
+			ok, err := cmp(r)
+			if err != nil {
+				return err
+			}
+			if ok {
 				list.Remove(iterator.Index())
 				count--
 			}
@@ -189,7 +193,11 @@ func (l *List) LRem(key string, count int, cmp func(r *Record) bool) error {
 		for iterator.Prev() && count < 0 {
 			r := iterator.Value().(*Record)
 
-			if cmp(r) {
+			ok, err := cmp(r)
+			if err != nil {
+				return err
+			}
+			if ok {
 				list.Remove(iterator.Index())
 				count++
 			}

--- a/list_test.go
+++ b/list_test.go
@@ -125,8 +125,8 @@ func TestList_LRem(t *testing.T) {
 	// r1 r1 r1 r2 r1 r2
 	expectRecords := []*Record{records[0], records[0], records[0], records[1], records[0], records[1]}
 
-	cmp := func(r *Record) bool {
-		return bytes.Equal(r.E.Value, records[0].E.Value)
+	cmp := func(r *Record) (bool, error) {
+		return bytes.Equal(r.E.Value, records[0].E.Value), nil
 	}
 
 	// r1 r1 r1 r2 r2
@@ -141,8 +141,8 @@ func TestList_LRem(t *testing.T) {
 	expectRecords = expectRecords[2:]
 	ListCmp(t, list, key, expectRecords, false)
 
-	cmp = func(r *Record) bool {
-		return bytes.Equal(r.E.Value, records[1].E.Value)
+	cmp = func(r *Record) (bool, error) {
+		return bytes.Equal(r.E.Value, records[1].E.Value), nil
 	}
 
 	// r1

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,254 @@
+// Copyright 2023 The PromiseDB Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file expect in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func ListPush(t *testing.T, list *List, key string, r *Record, isLeft bool, expectError error) {
+	var e error
+	if isLeft {
+		e = list.LPush(key, r)
+	} else {
+		e = list.RPush(key, r)
+	}
+	assertErr(t, e, expectError)
+}
+
+func ListPop(t *testing.T, list *List, key string, isLeft bool, expectVal *Record, expectError error) {
+	var (
+		e error
+		r *Record
+	)
+
+	if isLeft {
+		r, e = list.LPop(key)
+	} else {
+		r, e = list.RPop(key)
+	}
+	if expectError != nil {
+		require.Equal(t, expectError, e)
+	} else {
+		require.NoError(t, e)
+		require.Equal(t, expectVal, r)
+	}
+}
+
+func ListCmp(t *testing.T, list *List, key string, expectRecords []*Record, isReverse bool) {
+	records, err := list.LRange(key, 0, -1)
+	require.NoError(t, err)
+
+	if isReverse {
+		for i := len(expectRecords) - 1; i >= 0; i-- {
+			require.Equal(t, expectRecords[i], records[len(expectRecords)-1-i])
+		}
+	} else {
+		for i := 0; i < len(expectRecords); i++ {
+			require.Equal(t, expectRecords[i], records[i])
+		}
+	}
+}
+
+func TestList_LPush(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(5)
+	key := string(GetTestBytes(0))
+
+	for i := 0; i < len(expectRecords); i++ {
+		ListPush(t, list, key, expectRecords[i], true, nil)
+	}
+
+	ListCmp(t, list, key, expectRecords, true)
+}
+
+func TestList_RPush(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(5)
+	key := string(GetTestBytes(0))
+
+	for i := 0; i < len(expectRecords); i++ {
+		ListPush(t, list, key, expectRecords[i], false, nil)
+	}
+
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func TestList_Pop(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(5)
+	key := string(GetTestBytes(0))
+
+	ListPop(t, list, key, true, nil, ErrListNotFound)
+
+	for i := 0; i < len(expectRecords); i++ {
+		ListPush(t, list, key, expectRecords[i], false, nil)
+	}
+
+	ListPop(t, list, key, true, expectRecords[0], nil)
+	expectRecords = expectRecords[1:]
+
+	ListPop(t, list, key, false, expectRecords[len(expectRecords)-1], nil)
+	expectRecords = expectRecords[:len(expectRecords)-1]
+
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func TestList_LRem(t *testing.T) {
+	list := NewList()
+	records := generateRecords(2)
+	key := string(GetTestBytes(0))
+
+	for i := 0; i < 3; i++ {
+		ListPush(t, list, key, records[0], false, nil)
+	}
+
+	ListPush(t, list, key, records[1], false, nil)
+	ListPush(t, list, key, records[0], false, nil)
+	ListPush(t, list, key, records[1], false, nil)
+
+	// r1 r1 r1 r2 r1 r2
+	expectRecords := []*Record{records[0], records[0], records[0], records[1], records[0], records[1]}
+
+	cmp := func(r *Record) bool {
+		return bytes.Equal(r.E.Value, records[0].E.Value)
+	}
+
+	// r1 r1 r1 r2 r2
+	err := list.LRem(key, -1, cmp)
+	require.NoError(t, err)
+	expectRecords = append(expectRecords[0:4], expectRecords[5:]...)
+	ListCmp(t, list, key, expectRecords, false)
+
+	// r1 r2 r2
+	err = list.LRem(key, 2, cmp)
+	require.NoError(t, err)
+	expectRecords = expectRecords[2:]
+	ListCmp(t, list, key, expectRecords, false)
+
+	cmp = func(r *Record) bool {
+		return bytes.Equal(r.E.Value, records[1].E.Value)
+	}
+
+	// r1
+	err = list.LRem(key, 0, cmp)
+	require.NoError(t, err)
+	expectRecords = expectRecords[0:1]
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func TestList_LSet(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(5)
+	key := string(GetTestBytes(0))
+
+	for i := 0; i < len(expectRecords); i++ {
+		ListPush(t, list, key, expectRecords[i], false, nil)
+	}
+
+	err := list.LSet(key, 3, expectRecords[4])
+	require.NoError(t, err)
+
+	expectRecords[3] = expectRecords[4]
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func TestList_LTrim(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(5)
+	key := string(GetTestBytes(0))
+
+	for i := 0; i < len(expectRecords); i++ {
+		ListPush(t, list, key, expectRecords[i], false, nil)
+	}
+
+	err := list.LTrim(key, 1, 3)
+	require.NoError(t, err)
+	expectRecords = expectRecords[1 : len(expectRecords)-1]
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func TestList_LRemByIndex(t *testing.T) {
+	list := NewList()
+	expectRecords := generateRecords(8)
+	key := string(GetTestBytes(0))
+
+	// r1 r2 r3 r4 r5 r6 r7 r8
+	for i := 0; i < 8; i++ {
+		ListPush(t, list, key, expectRecords[i], false, nil)
+	}
+
+	// r1 r2 r4 r5 r6 r7 r8
+	err := list.LRemByIndex(key, []int{2})
+	require.NoError(t, err)
+	expectRecords = append(expectRecords[0:2], expectRecords[3:]...)
+	ListCmp(t, list, key, expectRecords, false)
+
+	// r2 r6 r7 r8
+	err = list.LRemByIndex(key, []int{0, 2, 3})
+	require.NoError(t, err)
+	expectRecords = expectRecords[1:]
+	expectRecords = append(expectRecords[0:1], expectRecords[3:]...)
+	ListCmp(t, list, key, expectRecords, false)
+
+	err = list.LRemByIndex(key, []int{0, 0, 0})
+	require.NoError(t, err)
+	expectRecords = expectRecords[1:]
+	ListCmp(t, list, key, expectRecords, false)
+}
+
+func generateRecords(count int) []*Record {
+	bucket := []byte("bucket")
+	rand.Seed(time.Now().UnixNano())
+	records := make([]*Record, count)
+	for i := 0; i < count; i++ {
+		key := GetTestBytes(i)
+		val := GetRandomBytes(24)
+
+		metaData := &MetaData{
+			KeySize:    uint32(len(key)),
+			ValueSize:  uint32(len(val)),
+			Timestamp:  uint64(time.Now().Unix()),
+			TTL:        uint32(rand.Intn(3600)),
+			Flag:       uint16(rand.Intn(2)),
+			BucketSize: uint32(len(bucket)),
+			TxID:       uint64(rand.Intn(1000)),
+			Status:     uint16(rand.Intn(2)),
+			Ds:         uint16(rand.Intn(3)),
+			Crc:        rand.Uint32(),
+		}
+
+		record := &Record{
+			H: &Hint{
+				Key:     key,
+				FileID:  int64(i),
+				Meta:    metaData,
+				DataPos: uint64(rand.Uint32()),
+			},
+			E: &Entry{
+				Key:    key,
+				Value:  val,
+				Bucket: bucket,
+				Meta:   metaData,
+			},
+			Bucket: string(bucket),
+		}
+		records[i] = record
+	}
+	return records
+}

--- a/tx.go
+++ b/tx.go
@@ -518,13 +518,17 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry, offset int64) {
 		return
 	}
 
-	var h *Hint
+	var (
+		h *Hint
+		e *Entry
+	)
 	if tx.db.opt.EntryIdxMode == HintKeyAndRAMIdxMode {
 		h = NewHint().WithFileId(tx.db.ActiveFile.fileID).WithKey(entry.Key).WithMeta(entry.Meta).WithDataPos(uint64(offset))
-		entry = nil
+	} else {
+		e = entry
 	}
 
-	r := NewRecord().WithBucket(bucket).WithEntry(entry).WithHint(h)
+	r := NewRecord().WithBucket(bucket).WithEntry(e).WithHint(h)
 
 	switch entry.Meta.Flag {
 	case DataExpireListFlag:

--- a/tx.go
+++ b/tx.go
@@ -267,6 +267,11 @@ func (tx *Tx) Commit() (err error) {
 		if entry.Meta.Ds == DataStructureBPTree {
 			tx.buildBPTreeIdx(bucket, entry, e, offset, countFlag)
 		}
+
+		if entry.Meta.Ds == DataStructureList {
+			tx.buildListIdx(bucket, entry, offset)
+		}
+
 		if entry.Meta.Ds == DataStructureNone && entry.Meta.Flag == DataBPTreeBucketDeleteFlag {
 			tx.db.deleteBucket(DataStructureBPTree, bucket)
 		}
@@ -421,9 +426,9 @@ func (tx *Tx) buildIdxes() {
 			tx.buildSortedSetIdx(bucket, entry)
 		}
 
-		if entry.Meta.Ds == DataStructureList {
-			tx.buildListIdx(bucket, entry)
-		}
+		//if entry.Meta.Ds == DataStructureList {
+		//	tx.buildListIdx(bucket, entry)
+		//}
 
 		if entry.Meta.Ds == DataStructureNone {
 			if entry.Meta.Flag == DataSetBucketDeleteFlag {
@@ -505,13 +510,22 @@ func (tx *Tx) buildSortedSetIdx(bucket string, entry *Entry) {
 	}
 }
 
-func (tx *Tx) buildListIdx(bucket string, entry *Entry) {
+func (tx *Tx) buildListIdx(bucket string, entry *Entry, offset int64) {
 	l := tx.db.Index.getList(bucket)
 
 	key, value := entry.Key, entry.Value
 	if IsExpired(entry.Meta.TTL, entry.Meta.Timestamp) {
 		return
 	}
+
+	var h *Hint
+	if tx.db.opt.EntryIdxMode == HintKeyAndRAMIdxMode {
+		h = NewHint().WithFileId(tx.db.ActiveFile.fileID).WithKey(entry.Key).WithMeta(entry.Meta).WithDataPos(uint64(offset))
+		entry = nil
+	}
+
+	r := NewRecord().WithBucket(bucket).WithEntry(entry).WithHint(h)
+
 	switch entry.Meta.Flag {
 	case DataExpireListFlag:
 		t, _ := strconv2.StrToInt64(string(value))
@@ -519,15 +533,21 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry) {
 		l.TTL[string(key)] = ttl
 		l.TimeStamp[string(key)] = entry.Meta.Timestamp
 	case DataLPushFlag:
-		_, _ = l.LPush(string(key), value)
+		_ = l.LPush(string(key), r)
 	case DataRPushFlag:
-		_, _ = l.RPush(string(key), value)
+		_ = l.RPush(string(key), r)
 	case DataLRemFlag:
 		countAndValue := strings.Split(string(value), SeparatorForListKey)
 		count, _ := strconv2.StrToInt(countAndValue[0])
 		newValue := countAndValue[1]
 
-		_, _ = l.LRem(string(key), count, []byte(newValue))
+		_ = l.LRem(string(key), count, func(r *Record) (bool, error) {
+			v, err := tx.db.getValueByRecord(r)
+			if err != nil {
+				return false, err
+			}
+			return bytes.Equal([]byte(newValue), v), nil
+		})
 
 	case DataLPopFlag:
 		_, _ = l.LPop(string(key))
@@ -537,16 +557,16 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry) {
 		keyAndIndex := strings.Split(string(key), SeparatorForListKey)
 		newKey := keyAndIndex[0]
 		index, _ := strconv2.StrToInt(keyAndIndex[1])
-		_ = l.LSet(newKey, index, value)
+		_ = l.LSet(newKey, index, r)
 	case DataLTrimFlag:
 		keyAndStartIndex := strings.Split(string(key), SeparatorForListKey)
 		newKey := keyAndStartIndex[0]
 		start, _ := strconv2.StrToInt(keyAndStartIndex[1])
 		end, _ := strconv2.StrToInt(string(value))
-		_ = l.Ltrim(newKey, start, end)
+		_ = l.LTrim(newKey, start, end)
 	case DataLRemByIndex:
 		indexes, _ := UnmarshalInts(value)
-		_, _ = l.LRemByIndex(string(key), indexes)
+		_ = l.LRemByIndex(string(key), indexes)
 	}
 }
 

--- a/tx_bptree.go
+++ b/tx_bptree.go
@@ -165,25 +165,11 @@ func (tx *Tx) Get(bucket string, key []byte) (e *Entry, err error) {
 			}
 
 			if idxMode == HintKeyAndRAMIdxMode {
-				path := getDataPath(r.H.FileID, tx.db.opt.Dir)
-				df, err := tx.db.fm.getDataFile(path, tx.db.opt.SegmentSize)
+				e, err = tx.db.getEntryByHint(r.H)
 				if err != nil {
 					return nil, err
 				}
-				defer func(rwManager RWManager) {
-					err := rwManager.Release()
-					if err != nil {
-						return
-					}
-				}(df.rwManager)
-
-				payloadSize := r.H.Meta.PayloadSize()
-				item, err := df.ReadRecord(int(r.H.DataPos), payloadSize)
-				if err != nil {
-					return nil, fmt.Errorf("read err. pos %d, key %s, err %s", r.H.DataPos, string(key), err)
-				}
-
-				return item, nil
+				return e, nil
 			}
 		} else {
 			return nil, ErrNotFoundBucket

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -260,7 +260,7 @@ func TestTx_LRem(t *testing.T) {
 
 	bucket := "myBucket"
 	key := []byte("myList")
-	_, err := tx.LRem(bucket, key, 1, []byte("val"))
+	err := tx.LRem(bucket, key, 1, []byte("val"))
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestTx_LRem2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err = tx.LRem(bucket, []byte("fake_key"), 1, []byte("fake_val")); err == nil {
+		if err = tx.LRem(bucket, []byte("fake_key"), 1, []byte("fake_val")); err == nil {
 			t.Fatal("TestTx_LRem err")
 		} else {
 			tx.Rollback()
@@ -315,7 +315,7 @@ func TestTx_LRem2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err = tx.LRem(bucket, key, 1, []byte("a")); err != nil {
+		if err = tx.LRem(bucket, key, 1, []byte("a")); err != nil {
 			tx.Rollback()
 			t.Fatal(err)
 		} else {
@@ -358,7 +358,7 @@ func TestTx_LRem3(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := tx.LRem(bucket, key, 4, []byte("b"))
+		err := tx.LRem(bucket, key, 4, []byte("b"))
 		if err == nil {
 			t.Error("TestTx_LRem err")
 		}
@@ -371,7 +371,7 @@ func TestTx_LRem3(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := tx.LRem(bucket, []byte("myList2"), 4, []byte("b"))
+		err := tx.LRem(bucket, []byte("myList2"), 4, []byte("b"))
 		if err == nil {
 			t.Error("TestTx_LRem err")
 		}
@@ -384,8 +384,8 @@ func TestTx_LRem3(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		num, err := tx.LRem(bucket, []byte("myList2"), 1, []byte("b"))
-		if err != nil || num != 1 {
+		err := tx.LRem(bucket, []byte("myList2"), 1, []byte("b"))
+		if err != nil {
 			t.Error("TestTx_LRem err")
 		}
 		tx.Rollback()
@@ -410,8 +410,8 @@ func TestTx_LRem3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	num, err := tx.LRem(bucket, []byte("myList3"), 0, []byte("b"))
-	if err != nil || num != 2 {
+	err := tx.LRem(bucket, []byte("myList3"), 0, []byte("b"))
+	if err != nil {
 		t.Error("TestTx_LRem err")
 	}
 	tx.Rollback()
@@ -678,28 +678,24 @@ func TestTx_LRemByIndex(t *testing.T) {
 	bucket := "myBucket"
 	key := []byte("myList")
 
-	removedNum, err := tx.LRemByIndex(bucket, []byte("fake_key"))
-	assertions.Error(err, "TestTx_LRemByIndex")
-	assertions.Equal(0, removedNum, "TestTx_LRemByIndex")
+	err := tx.LRemByIndex(bucket, []byte("fake_key"))
+	assertions.NoError(err)
 	tx.Rollback()
 
 	InitDataForList(bucket, key, t)
 
 	tx, _ = db.Begin(true)
 
-	removedNum, err = tx.LRemByIndex(bucket, key, 1, 0, 8, -8)
+	err = tx.LRemByIndex(bucket, key, 1, 0, 8, -8)
 	assertions.NoError(err, "TestTx_LRemByIndex")
-	assertions.Equal(2, removedNum, "TestTx_LRemByIndex")
 
-	removedNum, err = tx.LRemByIndex(bucket, key, 88, -88)
+	err = tx.LRemByIndex(bucket, key, 88, -88)
 	assertions.NoError(err, "TestTx_LRemByIndex")
-	assertions.Equal(0, removedNum, "TestTx_LRemByIndex")
 
 	tx.Commit()
 
-	removedNum, err = tx.LRemByIndex(bucket, key, 1, 0, 8, -8)
+	err = tx.LRemByIndex(bucket, key, 1, 0, 8, -8)
 	assertions.Error(err, "TestTx_LRemByIndex")
-	assertions.Equal(0, removedNum, "TestTx_LRemByIndex")
 }
 
 func TestTx_ExpireList(t *testing.T) {

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -862,6 +862,7 @@ func TestTx_ListEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 		item, _ := listIdx.Items[string(key)].Get(0)
 		r, ok := item.(*Record)
 		require.True(t, ok)
+		require.Nil(t, r.H)
 		require.NotNil(t, r.E)
 		require.Equal(t, []byte("a"), r.E.Value)
 	})


### PR DESCRIPTION
By issue #354, even in **`HintKeyAndRAMIdxMode`**, the current List data structure **stores all values in memory**, which is not very reasonable. I fixed this issue by storing `Record` in the index.In the HintKeyAndRAMIdxMode, it is only necessary to store the Hint, and there is no need to store the Entry.

I refactored the List using a `doubly linked list` because using arrays would result in significant copying overhead when performing operations like LPush, LPop, and others.