### PR TITLE
feat: make Set support HintKeyAndRAMIdxMode

### DIFF
--- a/db.go
+++ b/db.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/nutsdb/nutsdb/ds/set"
 	"github.com/nutsdb/nutsdb/ds/zset"
 	"github.com/xujiajun/utils/filesystem"
 	"github.com/xujiajun/utils/strconv2"
@@ -818,7 +817,7 @@ func (db *DB) deleteBucket(ds uint16, bucket string) {
 // buildSetIdx builds set index when opening the DB.
 func (db *DB) buildSetIdx(bucket string, r *Record) error {
 	if _, ok := db.SetIdx[bucket]; !ok {
-		db.SetIdx[bucket] = set.New()
+		db.SetIdx[bucket] = NewSet()
 	}
 
 	if r.E == nil {
@@ -826,7 +825,7 @@ func (db *DB) buildSetIdx(bucket string, r *Record) error {
 	}
 
 	if r.H.Meta.Flag == DataSetFlag {
-		if err := db.SetIdx[bucket].SAdd(string(r.E.Key), r.E.Value); err != nil {
+		if err := db.SetIdx[bucket].SAdd(string(r.E.Key), [][]byte{r.E.Value}, []*Record{r}); err != nil {
 			return fmt.Errorf("when build SetIdx SAdd index err: %s", err)
 		}
 	}
@@ -984,6 +983,20 @@ func (db *DB) buildIndexes() (err error) {
 
 	// build hint index
 	return db.buildHintIdx(dataFileIds)
+}
+
+func (db *DB) buildRecordByEntryAndOffset(entry *Entry, offset int64) *Record {
+	var (
+		h *Hint
+		e *Entry
+	)
+	if db.opt.EntryIdxMode == HintKeyAndRAMIdxMode {
+		h = NewHint().WithFileId(db.ActiveFile.fileID).WithKey(entry.Key).WithMeta(entry.Meta).WithDataPos(uint64(offset))
+	} else {
+		e = entry
+	}
+
+	return NewRecord().WithBucket(string(entry.Bucket)).WithEntry(e).WithHint(h)
 }
 
 // managed calls a block of code that is fully contained in a transaction.

--- a/index.go
+++ b/index.go
@@ -1,7 +1,6 @@
 package nutsdb
 
 import (
-	"github.com/nutsdb/nutsdb/ds/set"
 	"github.com/nutsdb/nutsdb/ds/zset"
 )
 
@@ -9,7 +8,7 @@ import (
 type BPTreeIdx map[string]*BPTree
 
 // SetIdx represents the set index
-type SetIdx map[string]*set.Set
+type SetIdx map[string]*Set
 
 // SortedSetIdx represents the sorted set index
 type SortedSetIdx map[string]*zset.SortedSet

--- a/merge.go
+++ b/merge.go
@@ -221,7 +221,11 @@ func (db *DB) isPendingMergeEntry(entry *Entry) bool {
 	if entry.Meta.Ds == DataStructureSet {
 		setIdx, exist := db.SetIdx[string(entry.Bucket)]
 		if exist {
-			if setIdx.SIsMember(string(entry.Key), entry.Value) {
+			isMember, err := setIdx.SIsMember(string(entry.Key), entry.Value)
+			if err != nil {
+				return false
+			}
+			if isMember {
 				return true
 			}
 		}

--- a/set.go
+++ b/set.go
@@ -83,8 +83,8 @@ func (s *Set) SRem(key string, values ...[]byte) error {
 	return nil
 }
 
-// SExist returns whether it has the set at given key.
-func (s *Set) SExist(key string) bool {
+// SHasKey returns whether it has the set at given key.
+func (s *Set) SHasKey(key string) bool {
 	if _, ok := s.M[key]; ok {
 		return true
 	}
@@ -93,7 +93,7 @@ func (s *Set) SExist(key string) bool {
 
 // SPop removes and returns one or more random elements from the set value store at key.
 func (s *Set) SPop(key string) *Record {
-	if !s.SExist(key) {
+	if !s.SHasKey(key) {
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func (s *Set) SPop(key string) *Record {
 
 // SCard Returns the set cardinality (number of elements) of the set stored at key.
 func (s *Set) SCard(key string) int {
-	if !s.SExist(key) {
+	if !s.SHasKey(key) {
 		return 0
 	}
 
@@ -116,7 +116,7 @@ func (s *Set) SCard(key string) int {
 
 // SDiff Returns the members of the set resulting from the difference between the first set and all the successive sets.
 func (s *Set) SDiff(key1, key2 string) ([]*Record, error) {
-	if !s.SExist(key1) || !s.SExist(key2) {
+	if !s.SHasKey(key1) || !s.SHasKey(key2) {
 		return nil, ErrSetNotExist
 	}
 
@@ -132,7 +132,7 @@ func (s *Set) SDiff(key1, key2 string) ([]*Record, error) {
 
 // SInter Returns the members of the set resulting from the intersection of all the given sets.
 func (s *Set) SInter(key1, key2 string) ([]*Record, error) {
-	if !s.SExist(key1) || !s.SExist(key2) {
+	if !s.SHasKey(key1) || !s.SHasKey(key2) {
 		return nil, ErrSetNotExist
 	}
 
@@ -203,7 +203,7 @@ func (s *Set) SMembers(key string) ([]*Record, error) {
 
 // SMove moves member from the set at source to the set at destination.
 func (s *Set) SMove(key1, key2 string, value []byte) (bool, error) {
-	if !s.SExist(key1) || !s.SExist(key2) {
+	if !s.SHasKey(key1) || !s.SHasKey(key2) {
 		return false, ErrSetNotExist
 	}
 
@@ -240,7 +240,7 @@ func (s *Set) SMove(key1, key2 string, value []byte) (bool, error) {
 
 // SUnion returns the members of the set resulting from the union of all the given sets.
 func (s *Set) SUnion(key1, key2 string) ([]*Record, error) {
-	if !s.SExist(key1) || !s.SExist(key2) {
+	if !s.SHasKey(key1) || !s.SHasKey(key2) {
 		return nil, ErrSetNotExist
 	}
 

--- a/set.go
+++ b/set.go
@@ -1,0 +1,256 @@
+// Copyright 2023 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"errors"
+	"hash/fnv"
+)
+
+var (
+	// ErrSetNotExist is returned when the key not exist.
+	ErrSetNotExist = errors.New("key not exist")
+
+	// ErrItemEmpty is returned when the item received is nil
+	ErrItemEmpty = errors.New("item empty")
+)
+
+var fnvHash = fnv.New32a()
+
+type Set struct {
+	M map[string]map[uint32]*Record
+}
+
+func NewSet() *Set {
+	return &Set{
+		M: map[string]map[uint32]*Record{},
+	}
+}
+
+// SAdd adds the specified members to the set stored at key.
+func (s *Set) SAdd(key string, values [][]byte, records []*Record) error {
+	set, ok := s.M[key]
+	if !ok {
+		s.M[key] = map[uint32]*Record{}
+		set = s.M[key]
+	}
+
+	for i, value := range values {
+		hash, err := getFnv32(value)
+		if err != nil {
+			return err
+		}
+		set[hash] = records[i]
+	}
+
+	return nil
+}
+
+// SRem removes the specified members from the set stored at key.
+func (s *Set) SRem(key string, values ...[]byte) error {
+	set, ok := s.M[key]
+	if !ok {
+		return ErrKeyNotFound
+	}
+
+	if len(values) == 0 || values[0] == nil {
+		return ErrItemEmpty
+	}
+
+	for _, value := range values {
+		hash, err := getFnv32(value)
+		if err != nil {
+			return err
+		}
+		delete(set, hash)
+	}
+
+	return nil
+}
+
+// SExist returns whether it has the set at given key.
+func (s *Set) SExist(key string) bool {
+	if _, ok := s.M[key]; ok {
+		return true
+	}
+	return false
+}
+
+// SPop removes and returns one or more random elements from the set value store at key.
+func (s *Set) SPop(key string) *Record {
+	if !s.SExist(key) {
+		return nil
+	}
+
+	for hash, record := range s.M[key] {
+		delete(s.M[key], hash)
+		return record
+	}
+
+	return nil
+}
+
+// SCard Returns the set cardinality (number of elements) of the set stored at key.
+func (s *Set) SCard(key string) int {
+	if !s.SExist(key) {
+		return 0
+	}
+
+	return len(s.M[key])
+}
+
+// SDiff Returns the members of the set resulting from the difference between the first set and all the successive sets.
+func (s *Set) SDiff(key1, key2 string) ([]*Record, error) {
+	if !s.SExist(key1) || !s.SExist(key2) {
+		return nil, ErrSetNotExist
+	}
+
+	records := make([]*Record, 0)
+
+	for hash, record := range s.M[key1] {
+		if _, ok := s.M[key2][hash]; !ok {
+			records = append(records, record)
+		}
+	}
+	return records, nil
+}
+
+// SInter Returns the members of the set resulting from the intersection of all the given sets.
+func (s *Set) SInter(key1, key2 string) ([]*Record, error) {
+	if !s.SExist(key1) || !s.SExist(key2) {
+		return nil, ErrSetNotExist
+	}
+
+	records := make([]*Record, 0)
+
+	for hash, record := range s.M[key1] {
+		if _, ok := s.M[key2][hash]; ok {
+			records = append(records, record)
+		}
+	}
+	return records, nil
+}
+
+// SIsMember Returns if member is a member of the set stored at key.
+func (s *Set) SIsMember(key string, value []byte) (bool, error) {
+	if _, ok := s.M[key]; !ok {
+		return false, ErrSetNotExist
+	}
+
+	hash, err := getFnv32(value)
+	if err != nil {
+		return false, err
+	}
+
+	if _, ok := s.M[key][hash]; ok {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// SAreMembers Returns if members are members of the set stored at key.
+// For multiple items it returns true only if all the items exist.
+func (s *Set) SAreMembers(key string, values ...[]byte) (bool, error) {
+	if _, ok := s.M[key]; !ok {
+		return false, ErrSetNotExist
+	}
+
+	for _, value := range values {
+
+		hash, err := getFnv32(value)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := s.M[key][hash]; !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// SMembers returns all the members of the set value stored at key.
+func (s *Set) SMembers(key string) ([]*Record, error) {
+	if _, ok := s.M[key]; !ok {
+		return nil, ErrSetNotExist
+	}
+
+	records := make([]*Record, 0)
+
+	for _, record := range s.M[key] {
+		records = append(records, record)
+	}
+
+	return nil, nil
+}
+
+// SMove moves member from the set at source to the set at destination.
+func (s *Set) SMove(key1, key2 string, value []byte) (bool, error) {
+	if !s.SExist(key1) || !s.SExist(key2) {
+		return false, ErrSetNotExist
+	}
+
+	hash, err := getFnv32(value)
+	if err != nil {
+		return false, err
+	}
+
+	if record, ok := s.M[key2][hash]; !ok {
+		err := s.SAdd(key2, [][]byte{value}, []*Record{record})
+		if err != nil {
+			return false, err
+		}
+	}
+
+	err = s.SRem(key1, value)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// SUnion returns the members of the set resulting from the union of all the given sets.
+func (s *Set) SUnion(key1, key2 string) ([]*Record, error) {
+	if !s.SExist(key1) || !s.SExist(key2) {
+		return nil, ErrSetNotExist
+	}
+
+	records, err := s.SMembers(key1)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for hash, record := range s.M[key2] {
+		if _, ok := s.M[key1][hash]; !ok {
+			records = append(records, record)
+		}
+	}
+
+	return records, nil
+}
+
+func getFnv32(value []byte) (uint32, error) {
+	_, err := fnvHash.Write(value)
+	if err != nil {
+		return 0, err
+	}
+	hash := fnvHash.Sum32()
+	fnvHash.Reset()
+	return hash, nil
+}

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,445 @@
+// Copyright 2023 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSet_SAdd(t *testing.T) {
+	set := NewSet()
+	key := "key"
+	expectRecords := generateRecords(3)
+
+	values := make([][]byte, 3)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+
+	ok, err := set.SAreMembers(key, values...)
+	require.True(t, ok)
+	require.NoError(t, err)
+}
+
+func TestSet_SRem(t *testing.T) {
+	set := NewSet()
+	key := "key"
+	expectRecords := generateRecords(4)
+	values := make([][]byte, 4)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+
+	require.NoError(t, set.SRem(key, values[0]))
+	require.NoError(t, set.SRem(key, values[1:]...))
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+	require.NoError(t, set.SRem(key, values...))
+
+	require.Error(t, set.SRem("fake key", values...))
+	require.Error(t, set.SRem(key, nil))
+}
+
+func TestSet_SDiff(t *testing.T) {
+	set := NewSet()
+
+	key1 := "set1"
+	key2 := "set2"
+	key3 := "set3"
+	key4 := "set4"
+
+	expectRecords := generateRecords(10)
+
+	values := make([][]byte, 10)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
+	require.NoError(t, set.SAdd(key2, values[2:6], expectRecords[2:6]))
+	require.NoError(t, set.SAdd(key3, values[2:7], expectRecords[2:7]))
+	require.NoError(t, set.SAdd(key4, values[7:], expectRecords[7:]))
+
+	type args struct {
+		key1 string
+		key2 string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		set     *Set
+		want    []*Record
+		wantErr bool
+	}{
+		{"normal set diff1", args{key1, key2}, set, expectRecords[:2], false},
+		{"normal set diff2", args{key1, key4}, set, expectRecords[:5], false},
+		{"normal set diff3", args{key3, key2}, set, expectRecords[6:7], false},
+		{"first fake set", args{"fake_key1", key2}, set, nil, true},
+		{"second fake set", args{key1, "fake_key2"}, set, nil, true},
+		{"two fake set", args{"fake_key1", "fake_key2"}, set, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.set.SDiff(tt.args.key1, tt.args.key2)
+			if (err != nil) != tt.wantErr {
+				require.Errorf(t, err, "Get() error = %v, wantErr %v", tt.wantErr)
+			}
+			require.ElementsMatchf(t, tt.want, got, "Get() got = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func TestSet_SCard(t *testing.T) {
+	set := NewSet()
+
+	key1 := "set1"
+	key2 := "set2"
+	key3 := "set3"
+	key4 := "set4"
+
+	expectRecords := generateRecords(10)
+
+	values := make([][]byte, 10)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
+	require.NoError(t, set.SAdd(key2, values[2:6], expectRecords[2:6]))
+	require.NoError(t, set.SAdd(key3, values[2:7], expectRecords[2:7]))
+	require.NoError(t, set.SAdd(key4, values[7:], expectRecords[7:]))
+
+	tests := []struct {
+		name string
+		key  string
+		set  *Set
+		want int
+	}{
+		{"normal set", key1, set, 5},
+		{"normal set", key2, set, 4},
+		{"normal set", key3, set, 5},
+		{"fake key", "key_fake", set, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.set.SCard(tt.key)
+			require.Equalf(t, tt.want, got, "TestSet_SCard err")
+		})
+	}
+}
+
+func TestSet_SInter(t *testing.T) {
+	set := NewSet()
+
+	key1 := "set1"
+	key2 := "set2"
+	key3 := "set3"
+	key4 := "set4"
+
+	expectRecords := generateRecords(10)
+
+	values := make([][]byte, 10)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
+	require.NoError(t, set.SAdd(key2, values[2:6], expectRecords[2:6]))
+	require.NoError(t, set.SAdd(key3, values[2:7], expectRecords[2:7]))
+	require.NoError(t, set.SAdd(key4, values[7:], expectRecords[7:]))
+
+	type args struct {
+		key1 string
+		key2 string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		set     *Set
+		want    []*Record
+		wantErr bool
+	}{
+		{"normal set inter1", args{key1, key2}, set, []*Record{expectRecords[2], expectRecords[3], expectRecords[4]}, false},
+		{"normal set inter1", args{key2, key3}, set, []*Record{expectRecords[2], expectRecords[3], expectRecords[4], expectRecords[5]}, false},
+		{"normal set inter2", args{key1, key4}, set, nil, false},
+		{"first fake set", args{"fake_key1", key2}, set, nil, true},
+		{"second fake set", args{key1, "fake_key2"}, set, nil, true},
+		{"two fake set", args{"fake_key1", "fake_key2"}, set, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.set.SInter(tt.args.key1, tt.args.key2)
+			if (err != nil) != tt.wantErr {
+				require.Errorf(t, err, "Get() error = %v, wantErr %v", tt.wantErr)
+			}
+			require.ElementsMatchf(t, tt.want, got, "Get() got = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func TestSet_SMembers(t *testing.T) {
+	set := NewSet()
+
+	key := "set"
+
+	expectRecords := generateRecords(3)
+
+	values := make([][]byte, 3)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+
+	tests := []struct {
+		name    string
+		key     string
+		set     *Set
+		want    []*Record
+		wantErr bool
+	}{
+		{"normal SMembers", key, set, expectRecords[0:1], false},
+		{"normal SMembers", key, set, expectRecords[1:], false},
+		{"normal SMembers", key, set, expectRecords, false},
+		{"fake key", "fake_key", set, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.set.SMembers(tt.key)
+			if (err != nil) != tt.wantErr {
+				require.Errorf(t, err, "Get() error = %v, wantErr %v", tt.wantErr)
+			}
+			require.Subsetf(t, got, tt.want, "SInter() got = %v, want = %v", got, tt.want)
+		})
+	}
+}
+
+func TestSet_SMove(t *testing.T) {
+	set := NewSet()
+
+	key1 := "set1"
+	key2 := "set2"
+
+	expectRecords := generateRecords(3)
+	values := make([][]byte, 3)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key1, values[:2], expectRecords[:2]))
+	require.NoError(t, set.SAdd(key2, values[2:], expectRecords[2:]))
+
+	type args struct {
+		key1 string
+		key2 string
+		item []byte
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		set       *Set
+		want1     []*Record
+		want2     []*Record
+		expectErr error
+	}{
+		{"normal SMove", args{key1, key2, values[1]}, set, expectRecords[0:1], expectRecords[1:], nil},
+		{"not exist member SMove", args{key1, key2, values[2]}, set, nil, nil, ErrSetMemberNotExist},
+		{"fake key SMove1", args{"fake key", key2, values[2]}, set, nil, nil, ErrSetNotExist},
+		{"fake key SMove", args{key1, "fake key", values[2]}, set, nil, nil, ErrSetNotExist},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.set.SMove(tt.args.key1, tt.args.key2, tt.args.item)
+			if tt.expectErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectErr, err)
+			} else {
+				got1, _ := tt.set.SMembers(tt.args.key1)
+				got2, _ := tt.set.SMembers(tt.args.key2)
+				require.ElementsMatchf(t, got1, tt.want1, "SMove() got = %v, want = %v", got1, tt.want1)
+				require.ElementsMatchf(t, got2, tt.want2, "SMove() got = %v, want = %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestSet_SPop(t *testing.T) {
+	set := NewSet()
+
+	key := "set"
+
+	expectRecords := generateRecords(2)
+	values := make([][]byte, 2)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+	m := map[*Record]struct{}{}
+	for _, expectRecord := range expectRecords {
+		m[expectRecord] = struct{}{}
+	}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+
+	tests := []struct {
+		name string
+		key  string
+		set  *Set
+		ok   bool
+	}{
+		{"normal set SPop", key, set, true},
+		{"normal set SPop", key, set, true},
+		{"normal set SPop", key, set, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := tt.set.SPop(tt.key)
+			_, ok := m[record]
+			require.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestSet_SIsMember(t *testing.T) {
+	set := NewSet()
+
+	key := "key"
+
+	expectRecords := generateRecords(1)
+	values := [][]byte{expectRecords[0].E.Value}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+	tests := []struct {
+		key       string
+		val       []byte
+		ok        bool
+		expectErr error
+	}{
+		{key, values[0], true, nil},
+		{key, GetRandomBytes(24), false, nil},
+		{"fake key", GetRandomBytes(24), false, ErrSetNotExist},
+	}
+	for _, tt := range tests {
+		ok, err := set.SIsMember(tt.key, tt.val)
+		if tt.expectErr != nil {
+			require.Equal(t, tt.expectErr, err)
+		} else {
+			require.Equal(t, tt.ok, ok)
+		}
+	}
+}
+
+func TestSet_SAreMembers(t *testing.T) {
+	set := NewSet()
+
+	key := "set"
+
+	expectRecords := generateRecords(4)
+	values := make([][]byte, 4)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key, values, expectRecords))
+	tests := []struct {
+		key       string
+		val       [][]byte
+		ok        bool
+		expectErr error
+	}{
+		{key, values[0:2], true, nil},
+		{key, values[2:], true, nil},
+		{key, values, true, nil},
+		{key, [][]byte{GetRandomBytes(24)}, false, nil},
+		{"fake key", values, true, ErrSetNotExist},
+	}
+	for _, tt := range tests {
+		ok, err := set.SAreMembers(tt.key, tt.val...)
+		if tt.expectErr != nil {
+			require.Equal(t, tt.expectErr, err)
+		} else {
+			require.Equal(t, tt.ok, ok)
+		}
+	}
+}
+
+func TestSet_SUnion(t *testing.T) {
+	set := NewSet()
+
+	key1 := "set1"
+	key2 := "set2"
+	key3 := "set3"
+	key4 := "set4"
+
+	expectRecords := generateRecords(10)
+
+	values := make([][]byte, 10)
+	for i := range expectRecords {
+		values[i] = expectRecords[i].E.Value
+	}
+
+	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
+	require.NoError(t, set.SAdd(key2, values[2:6], expectRecords[2:6]))
+	require.NoError(t, set.SAdd(key3, values[2:7], expectRecords[2:7]))
+	require.NoError(t, set.SAdd(key4, values[7:], expectRecords[7:]))
+
+	type args struct {
+		key1 string
+		key2 string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		set     *Set
+		want    []*Record
+		wantErr bool
+	}{
+		{"normal set Union1", args{key1, key4}, set,
+			[]*Record{expectRecords[0], expectRecords[1], expectRecords[2], expectRecords[3], expectRecords[4], expectRecords[7], expectRecords[8], expectRecords[9]},
+			false},
+		{
+			"normal set Union2", args{key2, key3}, set,
+			[]*Record{expectRecords[2], expectRecords[3], expectRecords[4], expectRecords[5], expectRecords[6]},
+			false,
+		},
+		{"first fake set", args{"fake_key1", key2}, set, nil, true},
+		{"second fake set", args{key1, "fake_key2"}, set, nil, true},
+		{"two fake set", args{"fake_key1", "fake_key2"}, set, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.set.SUnion(tt.args.key1, tt.args.key2)
+			if (err != nil) != tt.wantErr {
+				require.Errorf(t, err, "Get() error = %v, wantErr %v", tt.wantErr)
+			}
+			require.ElementsMatchf(t, tt.want, got, "Get() got = %v, want %v", got, tt.want)
+		})
+	}
+}

--- a/tx.go
+++ b/tx.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
-	"github.com/nutsdb/nutsdb/ds/set"
 	"github.com/nutsdb/nutsdb/ds/zset"
 	"github.com/xujiajun/utils/strconv2"
 )
@@ -272,6 +271,10 @@ func (tx *Tx) Commit() (err error) {
 			tx.buildListIdx(bucket, entry, offset)
 		}
 
+		if entry.Meta.Ds == DataStructureSet {
+			tx.buildSetIdx(bucket, entry, offset)
+		}
+
 		if entry.Meta.Ds == DataStructureNone && entry.Meta.Flag == DataBPTreeBucketDeleteFlag {
 			tx.db.deleteBucket(DataStructureBPTree, bucket)
 		}
@@ -418,17 +421,9 @@ func (tx *Tx) buildIdxes() {
 
 		bucket := string(entry.Bucket)
 
-		if entry.Meta.Ds == DataStructureSet {
-			tx.buildSetIdx(bucket, entry)
-		}
-
 		if entry.Meta.Ds == DataStructureSortedSet {
 			tx.buildSortedSetIdx(bucket, entry)
 		}
-
-		//if entry.Meta.Ds == DataStructureList {
-		//	tx.buildListIdx(bucket, entry)
-		//}
 
 		if entry.Meta.Ds == DataStructureNone {
 			if entry.Meta.Flag == DataSetBucketDeleteFlag {
@@ -472,9 +467,9 @@ func (tx *Tx) buildBPTreeIdx(bucket string, entry, e *Entry, offset int64, count
 	}
 }
 
-func (tx *Tx) buildSetIdx(bucket string, entry *Entry) {
+func (tx *Tx) buildSetIdx(bucket string, entry *Entry, offset int64) {
 	if _, ok := tx.db.SetIdx[bucket]; !ok {
-		tx.db.SetIdx[bucket] = set.New()
+		tx.db.SetIdx[bucket] = NewSet()
 	}
 
 	if entry.Meta.Flag == DataDeleteFlag {
@@ -482,7 +477,8 @@ func (tx *Tx) buildSetIdx(bucket string, entry *Entry) {
 	}
 
 	if entry.Meta.Flag == DataSetFlag {
-		_ = tx.db.SetIdx[bucket].SAdd(string(entry.Key), entry.Value)
+		r := tx.db.buildRecordByEntryAndOffset(entry, offset)
+		_ = tx.db.SetIdx[bucket].SAdd(string(entry.Key), [][]byte{entry.Value}, []*Record{r})
 	}
 }
 
@@ -518,18 +514,6 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry, offset int64) {
 		return
 	}
 
-	var (
-		h *Hint
-		e *Entry
-	)
-	if tx.db.opt.EntryIdxMode == HintKeyAndRAMIdxMode {
-		h = NewHint().WithFileId(tx.db.ActiveFile.fileID).WithKey(entry.Key).WithMeta(entry.Meta).WithDataPos(uint64(offset))
-	} else {
-		e = entry
-	}
-
-	r := NewRecord().WithBucket(bucket).WithEntry(e).WithHint(h)
-
 	switch entry.Meta.Flag {
 	case DataExpireListFlag:
 		t, _ := strconv2.StrToInt64(string(value))
@@ -537,8 +521,10 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry, offset int64) {
 		l.TTL[string(key)] = ttl
 		l.TimeStamp[string(key)] = entry.Meta.Timestamp
 	case DataLPushFlag:
+		r := tx.db.buildRecordByEntryAndOffset(entry, offset)
 		_ = l.LPush(string(key), r)
 	case DataRPushFlag:
+		r := tx.db.buildRecordByEntryAndOffset(entry, offset)
 		_ = l.RPush(string(key), r)
 	case DataLRemFlag:
 		countAndValue := strings.Split(string(value), SeparatorForListKey)
@@ -561,6 +547,7 @@ func (tx *Tx) buildListIdx(bucket string, entry *Entry, offset int64) {
 		keyAndIndex := strings.Split(string(key), SeparatorForListKey)
 		newKey := keyAndIndex[0]
 		index, _ := strconv2.StrToInt(keyAndIndex[1])
+		r := tx.db.buildRecordByEntryAndOffset(entry, offset)
 		_ = l.LSet(newKey, index, r)
 	case DataLTrimFlag:
 		keyAndStartIndex := strings.Split(string(key), SeparatorForListKey)

--- a/tx_set.go
+++ b/tx_set.go
@@ -136,7 +136,7 @@ func (tx *Tx) SHasKey(bucket string, key []byte) (bool, error) {
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		return set.SExist(string(key)), nil
+		return set.SHasKey(string(key)), nil
 	}
 
 	return false, ErrBucketNotFound
@@ -271,11 +271,11 @@ func (tx *Tx) SMoveByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 		return false, ErrBucketAndKey(bucket2, key1)
 	}
 
-	if !set1.SExist(string(key1)) {
+	if !set1.SHasKey(string(key1)) {
 		return false, ErrNotFoundKeyInBucket(bucket1, key1)
 	}
 
-	if !set2.SExist(string(key2)) {
+	if !set2.SHasKey(string(key2)) {
 		return false, ErrNotFoundKeyInBucket(bucket2, key2)
 	}
 
@@ -339,11 +339,11 @@ func (tx *Tx) SUnionByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, ke
 		return nil, ErrBucketAndKey(bucket2, key1)
 	}
 
-	if !set1.SExist(string(key1)) {
+	if !set1.SHasKey(string(key1)) {
 		return nil, ErrNotFoundKeyInBucket(bucket1, key1)
 	}
 
-	if !set2.SExist(string(key2)) {
+	if !set2.SHasKey(string(key2)) {
 		return nil, ErrNotFoundKeyInBucket(bucket2, key2)
 	}
 

--- a/tx_set.go
+++ b/tx_set.go
@@ -285,10 +285,16 @@ func (tx *Tx) SMoveByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 	}
 
 	if r, ok := set2.M[string(key2)][hash]; !ok {
-		set2.SAdd(string(key2), [][]byte{item}, []*Record{r})
+		err := set2.SAdd(string(key2), [][]byte{item}, []*Record{r})
+		if err != nil {
+			return false, err
+		}
 	}
 
-	set1.SRem(string(key1), item)
+	err = set1.SRem(string(key1), item)
+	if err != nil {
+		return false, err
+	}
 
 	return true, nil
 }

--- a/tx_set.go
+++ b/tx_set.go
@@ -17,30 +17,33 @@ package nutsdb
 import (
 	"time"
 
-	"github.com/nutsdb/nutsdb/ds/set"
 	"github.com/pkg/errors"
 )
 
-func (tx *Tx) sPut(bucket string, key []byte, dataFlag uint16, items ...[]byte) error {
+func (tx *Tx) sPut(bucket string, key []byte, dataFlag uint16, values ...[]byte) error {
 
 	if dataFlag == DataSetFlag {
 
-		filter := make(map[string]struct{})
+		filter := make(map[uint32]struct{})
 
 		if set, ok := tx.db.SetIdx[bucket]; ok {
 
 			if _, ok := set.M[string(key)]; ok {
-				for item := range set.M[string(key)] {
-					filter[item] = struct{}{}
+				for hash := range set.M[string(key)] {
+					filter[hash] = struct{}{}
 				}
 			}
 
 		}
 
-		for _, item := range items {
-			if _, ok := filter[string(item)]; !ok {
-				filter[string(item)] = struct{}{}
-				err := tx.put(bucket, key, item, Persistent, dataFlag, uint64(time.Now().Unix()), DataStructureSet)
+		for _, value := range values {
+			hash, err := getFnv32(value)
+			if err != nil {
+				return err
+			}
+			if _, ok := filter[hash]; !ok {
+				filter[hash] = struct{}{}
+				err := tx.put(bucket, key, value, Persistent, dataFlag, uint64(time.Now().Unix()), DataStructureSet)
 				if err != nil {
 					return err
 				}
@@ -48,9 +51,9 @@ func (tx *Tx) sPut(bucket string, key []byte, dataFlag uint16, items ...[]byte) 
 		}
 
 	} else {
-		for _, item := range items {
+		for _, value := range values {
 
-			err := tx.put(bucket, key, item, Persistent, dataFlag, uint64(time.Now().Unix()), DataStructureSet)
+			err := tx.put(bucket, key, value, Persistent, dataFlag, uint64(time.Now().Unix()), DataStructureSet)
 			if err != nil {
 				return err
 			}
@@ -91,23 +94,35 @@ func (tx *Tx) SIsMember(bucket string, key, item []byte) (bool, error) {
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		if !set.SIsMember(string(key), item) {
-			return false, ErrBucketNotFound
+		isMember, err := set.SIsMember(string(key), item)
+		if err != nil {
+			return false, err
 		}
-		return true, nil
+		return isMember, nil
 	}
 
 	return false, ErrBucketNotFound
 }
 
 // SMembers returns all the members of the set value stored int the bucket at given bucket and key.
-func (tx *Tx) SMembers(bucket string, key []byte) (list [][]byte, err error) {
+func (tx *Tx) SMembers(bucket string, key []byte) ([][]byte, error) {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		return set.SMembers(string(key))
+		items, err := set.SMembers(string(key))
+		if err != nil {
+			return nil, err
+		}
+		values := make([][]byte, len(items))
+		for i, item := range items {
+			value, err := tx.db.getValueByRecord(item)
+			if err != nil {
+				return nil, err
+			}
+			values[i] = value
+		}
 	}
 
 	return nil, ErrBucketNotFound
@@ -121,7 +136,7 @@ func (tx *Tx) SHasKey(bucket string, key []byte) (bool, error) {
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		return set.SHasKey(string(key)), nil
+		return set.SExist(string(key)), nil
 	}
 
 	return false, ErrBucketNotFound
@@ -134,8 +149,16 @@ func (tx *Tx) SPop(bucket string, key []byte) ([]byte, error) {
 	}
 
 	if _, ok := tx.db.SetIdx[bucket]; ok {
-		for item := range tx.db.SetIdx[bucket].M[string(key)] {
-			return []byte(item), tx.sPut(bucket, key, DataDeleteFlag, []byte(item))
+		for _, items := range tx.db.SetIdx[bucket].M[string(key)] {
+			value, err := tx.db.getValueByRecord(items)
+			if err != nil {
+				return nil, err
+			}
+			err = tx.sPut(bucket, key, DataDeleteFlag, value)
+			if err != nil {
+				return nil, err
+			}
+			return value, err
 		}
 	}
 
@@ -157,13 +180,25 @@ func (tx *Tx) SCard(bucket string, key []byte) (int, error) {
 
 // SDiffByOneBucket returns the members of the set resulting from the difference
 // between the first set and all the successive sets in one bucket.
-func (tx *Tx) SDiffByOneBucket(bucket string, key1, key2 []byte) (list [][]byte, err error) {
+func (tx *Tx) SDiffByOneBucket(bucket string, key1, key2 []byte) ([][]byte, error) {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		return set.SDiff(string(key1), string(key2))
+		items, err := set.SDiff(string(key1), string(key2))
+		if err != nil {
+			return nil, err
+		}
+		values := make([][]byte, len(items))
+		for i, item := range items {
+			value, err := tx.db.getValueByRecord(item)
+			if err != nil {
+				return nil, err
+			}
+			values[i] = value
+		}
+		return values, nil
 	}
 
 	return nil, ErrBucketNotFound
@@ -171,13 +206,13 @@ func (tx *Tx) SDiffByOneBucket(bucket string, key1, key2 []byte) (list [][]byte,
 
 // SDiffByTwoBuckets returns the members of the set resulting from the difference
 // between the first set and all the successive sets in two buckets.
-func (tx *Tx) SDiffByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key2 []byte) (list [][]byte, err error) {
+func (tx *Tx) SDiffByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key2 []byte) ([][]byte, error) {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
 
 	var (
-		set1, set2 *set.Set
+		set1, set2 *Set
 		ok         bool
 	)
 
@@ -189,13 +224,19 @@ func (tx *Tx) SDiffByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 		return nil, ErrBucketAndKey(bucket2, key2)
 	}
 
-	for item1 := range set1.M[string(key1)] {
-		if _, ok := set2.M[string(key2)][item1]; !ok {
-			list = append(list, []byte(item1))
+	values := make([][]byte, 0)
+
+	for hash, item := range set1.M[string(key1)] {
+		if _, ok := set2.M[string(key2)][hash]; !ok {
+			value, err := tx.db.getValueByRecord(item)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
 		}
 	}
 
-	return
+	return values, nil
 }
 
 // SMoveByOneBucket moves member from the set at source to the set at destination in one bucket.
@@ -218,7 +259,7 @@ func (tx *Tx) SMoveByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 	}
 
 	var (
-		set1, set2 *set.Set
+		set1, set2 *Set
 		ok         bool
 	)
 
@@ -230,16 +271,21 @@ func (tx *Tx) SMoveByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 		return false, ErrBucketAndKey(bucket2, key1)
 	}
 
-	if !set1.SHasKey(string(key1)) {
+	if !set1.SExist(string(key1)) {
 		return false, ErrNotFoundKeyInBucket(bucket1, key1)
 	}
 
-	if !set2.SHasKey(string(key2)) {
+	if !set2.SExist(string(key2)) {
 		return false, ErrNotFoundKeyInBucket(bucket2, key2)
 	}
 
-	if _, ok := set2.M[string(key2)][string(item)]; !ok {
-		set2.SAdd(string(key2), item)
+	hash, err := getFnv32(item)
+	if err != nil {
+		return false, err
+	}
+
+	if r, ok := set2.M[string(key2)][hash]; !ok {
+		set2.SAdd(string(key2), [][]byte{item}, []*Record{r})
 	}
 
 	set1.SRem(string(key1), item)
@@ -248,26 +294,40 @@ func (tx *Tx) SMoveByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key
 }
 
 // SUnionByOneBucket the members of the set resulting from the union of all the given sets in one bucket.
-func (tx *Tx) SUnionByOneBucket(bucket string, key1, key2 []byte) (list [][]byte, err error) {
+func (tx *Tx) SUnionByOneBucket(bucket string, key1, key2 []byte) ([][]byte, error) {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
 
 	if set, ok := tx.db.SetIdx[bucket]; ok {
-		return set.SUnion(string(key1), string(key2))
+		items, err := set.SUnion(string(key1), string(key2))
+		if err != nil {
+			return nil, err
+		}
+
+		values := make([][]byte, len(items))
+
+		for i, item := range items {
+			value, err := tx.db.getValueByRecord(item)
+			if err != nil {
+				return nil, err
+			}
+			values[i] = value
+		}
+		return values, nil
 	}
 
 	return nil, ErrBucket
 }
 
 // SUnionByTwoBuckets the members of the set resulting from the union of all the given sets in two buckets.
-func (tx *Tx) SUnionByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key2 []byte) (list [][]byte, err error) {
+func (tx *Tx) SUnionByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, key2 []byte) ([][]byte, error) {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
 
 	var (
-		set1, set2 *set.Set
+		set1, set2 *Set
 		ok         bool
 	)
 
@@ -279,25 +339,35 @@ func (tx *Tx) SUnionByTwoBuckets(bucket1 string, key1 []byte, bucket2 string, ke
 		return nil, ErrBucketAndKey(bucket2, key1)
 	}
 
-	if !set1.SHasKey(string(key1)) {
+	if !set1.SExist(string(key1)) {
 		return nil, ErrNotFoundKeyInBucket(bucket1, key1)
 	}
 
-	if !set2.SHasKey(string(key2)) {
+	if !set2.SExist(string(key2)) {
 		return nil, ErrNotFoundKeyInBucket(bucket2, key2)
 	}
 
-	for item1 := range set1.M[string(key1)] {
-		list = append(list, []byte(item1))
+	values := make([][]byte, 0)
+
+	for _, r := range set1.M[string(key1)] {
+		value, err := tx.db.getValueByRecord(r)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
 	}
 
-	for item2 := range set2.M[string(key2)] {
-		if _, ok := set1.M[string(key1)][item2]; !ok {
-			list = append(list, []byte(item2))
+	for hash, r := range set2.M[string(key2)] {
+		if _, ok := set1.M[string(key1)][hash]; !ok {
+			value, err := tx.db.getValueByRecord(r)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
 		}
 	}
 
-	return
+	return values, nil
 }
 
 // SKeys find all keys matching a given pattern

--- a/tx_set_test.go
+++ b/tx_set_test.go
@@ -545,7 +545,7 @@ func TestTx_SMoveByOneBucket(t *testing.T) {
 	}
 
 	ok, err = tx.SIsMember(bucket, key1, []byte("two"))
-	if ok || err == nil {
+	if ok {
 		t.Error("TestTx_SMoveByOneBucket err")
 	}
 
@@ -642,7 +642,7 @@ func TestTx_SMoveByTwoBuckets(t *testing.T) {
 	}
 
 	ok, err := tx.SIsMember(bucket1, key1, []byte("two"))
-	if ok || err == nil {
+	if ok {
 		t.Error("TestTx_SMoveByOneBucket err")
 	}
 
@@ -872,7 +872,7 @@ func opSIsMemberForTest(bucket string, key []byte, t *testing.T) {
 	}
 
 	ok, err = tx.SIsMember(bucket, key, []byte("World2"))
-	if ok || err == nil {
+	if ok {
 		t.Error("TestTx_SIsMember err")
 	}
 
@@ -932,7 +932,7 @@ func opSAreMembersForTest(bucket string, key []byte, t *testing.T) {
 	}
 
 	ok, err = tx.SAreMembers(bucket, key, []byte("Hello2"), []byte("World"))
-	if ok || err == nil {
+	if ok {
 		t.Error("TestTx_SAreMembers err")
 	}
 


### PR DESCRIPTION
I refactor the Set data structure to store `Record` rather than []byte, so it support HintKeyAndRAMIdxMode now.

I use fnv to calculate the hash of value and use that hash as the key of set.This may have some performance overhead, but fortunately fnv is very fast.