### PR TITLE
refactor: refactor unit test of tx_list

### DIFF
--- a/db.go
+++ b/db.go
@@ -306,7 +306,7 @@ func (db *DB) release() error {
 
 func (db *DB) getValueByRecord(r *Record) ([]byte, error) {
 	if r == nil {
-		return nil, errors.New("the record is nil")
+		return nil, ErrRecordIsNil
 	}
 
 	if r.V != nil {

--- a/db_error.go
+++ b/db_error.go
@@ -32,4 +32,7 @@ var (
 
 	// ErrNotSupportMergeWhenUsingList is returned calling 'Merge' when using list
 	ErrNotSupportMergeWhenUsingList = errors.New("not support merge when using list for now")
+
+	// ErrRecordIsNil is returned when Record is nil
+	ErrRecordIsNil = errors.New("the record is nil")
 )

--- a/list.go
+++ b/list.go
@@ -38,6 +38,9 @@ var (
 
 	// ErrEmptyList is returned when the list is empty.
 	ErrEmptyList = errors.New("the list is empty")
+
+	// ErrStartOrEnd is returned when start > end
+	ErrStartOrEnd = errors.New("start or end error")
 )
 
 const (
@@ -428,7 +431,7 @@ func checkBounds(start, end int, size int) (int, int, error) {
 	}
 
 	if start > end {
-		return 0, 0, errors.New("start or end error")
+		return 0, 0, ErrStartOrEnd
 	}
 
 	return start, end, nil


### PR DESCRIPTION
This pr is related with #403 .

What changed:

1. refactor code of unit test for `tx_list.go` (in order to unify the code style, define more `txXXX()` functions
2. add cases for `tx.LRem` with different `count`

Refactored cases and newly added cases were successfully tested in my local environment.