### PR TITLE
[feat]Serperate bucket from entry and build the bucket management system

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -46,6 +46,7 @@ func init() {
 }
 
 func TestBatchWrite(t *testing.T) {
+	t.Skip()
 	TestFlushPanic := func(t *testing.T, db *DB) {
 		wb, err := db.NewWriteBatch()
 		require.NoError(t, err)

--- a/batch_test.go
+++ b/batch_test.go
@@ -70,6 +70,7 @@ func TestBatchWrite(t *testing.T) {
 	}
 
 	testWrite := func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 		key := func(i int) []byte {
 			return []byte(fmt.Sprintf("%10d", i))
 		}

--- a/batch_test.go
+++ b/batch_test.go
@@ -46,7 +46,6 @@ func init() {
 }
 
 func TestBatchWrite(t *testing.T) {
-	t.Skip()
 	TestFlushPanic := func(t *testing.T, db *DB) {
 		wb, err := db.NewWriteBatch()
 		require.NoError(t, err)

--- a/bucket.go
+++ b/bucket.go
@@ -1,0 +1,89 @@
+package nutsdb
+
+import (
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+)
+
+var BucketMetaSize int64
+
+const (
+	IdSize = 8
+	DsSize = 2
+)
+
+type BucketOperation uint16
+
+const (
+	BucketInsertOperation = 1
+	BucketUpdateOperation = 2
+	BucketDeleteOperation = 3
+)
+
+var ErrBucketCrcInvalid = errors.New("bucket crc invalid")
+
+func init() {
+	BucketMetaSize = GetDiskSizeFromSingleObject(BucketMeta{})
+}
+
+// BucketMeta stores the meta info of a Bucket. E.g. the size of bucket it store in disk.
+type BucketMeta struct {
+	Crc  uint32
+	Size uint32
+	Op   BucketOperation
+}
+
+// Bucket is the disk structure of bucket
+type Bucket struct {
+	meta *BucketMeta
+	Id   uint64
+	Ds   Ds
+	Name string
+}
+
+func (meta *BucketMeta) Decode(bytes []byte) {
+	_ = bytes[BucketMetaSize]
+	crc := binary.LittleEndian.Uint32(bytes[:4])
+	size := binary.LittleEndian.Uint32(bytes[4:8])
+	op := binary.LittleEndian.Uint16(bytes[8:10])
+	meta.Crc = crc
+	meta.Size = size
+	meta.Op = BucketOperation(op)
+}
+
+func (b *Bucket) Encode() []byte {
+	entrySize := b.GetEntrySize()
+	buf := make([]byte, entrySize)
+	binary.LittleEndian.PutUint64(buf[BucketMetaSize:BucketMetaSize+IdSize], b.Id)
+	binary.LittleEndian.PutUint16(buf[BucketMetaSize+IdSize:BucketMetaSize+IdSize+DsSize], uint16(b.Ds))
+	copy(buf[BucketMetaSize+IdSize:], b.Name)
+	c32 := crc32.ChecksumIEEE(buf[4:])
+	b.meta.Crc = c32
+	return buf
+}
+
+func (b *Bucket) Decode(bytes []byte) error {
+	crc := b.meta.Crc
+	crcInDisk := crc32.ChecksumIEEE(bytes[4:])
+	if crc != crcInDisk {
+		return ErrBucketCrcInvalid
+	}
+
+	// parse the payload
+	id := binary.LittleEndian.Uint64(bytes[BucketMetaSize : BucketMetaSize+IdSize])
+	ds := binary.LittleEndian.Uint16(bytes[BucketMetaSize+IdSize : BucketMetaSize+IdSize+DsSize])
+	name := bytes[BucketMetaSize+IdSize+DsSize:]
+	b.Id = id
+	b.Name = string(name)
+	b.Ds = Ds(ds)
+	return nil
+}
+
+func (b *Bucket) GetEntrySize() int {
+	return int(BucketMetaSize) + b.GetPayloadSize()
+}
+
+func (b *Bucket) GetPayloadSize() int {
+	return IdSize + DsSize + len(b.Name)
+}

--- a/bucket.go
+++ b/bucket.go
@@ -16,9 +16,9 @@ const (
 type BucketOperation uint16
 
 const (
-	BucketInsertOperation = 1
-	BucketUpdateOperation = 2
-	BucketDeleteOperation = 3
+	BucketInsertOperation BucketOperation = 1
+	BucketUpdateOperation BucketOperation = 2
+	BucketDeleteOperation BucketOperation = 3
 )
 
 var ErrBucketCrcInvalid = errors.New("bucket crc invalid")
@@ -29,16 +29,24 @@ func init() {
 
 // BucketMeta stores the Meta info of a Bucket. E.g. the size of bucket it store in disk.
 type BucketMeta struct {
-	Crc  uint32
-	Op   BucketOperation
+	Crc uint32
+	// Op: Mark the latest operation (e.g. delete, insert, update) for this bucket.
+	Op BucketOperation
+	// Size: the size of payload.
 	Size uint32
 }
 
 // Bucket is the disk structure of bucket
 type Bucket struct {
+	// Meta: the metadata for this bucket
 	Meta *BucketMeta
-	Id   uint64
-	Ds   Ds
+	// Id: is the marker for this bucket, every bucket creation activity will generate a new Id for it.
+	// for example. If you have a bucket called "bucket_1", and you just delete bucket and create it again.
+	// the last bucket will have a different Id from the previous one.
+	Id uint64
+	// Ds: the data structure for this bucket. (List, Set, SortSet, String)
+	Ds Ds
+	// Name: the name of this bucket.
 	Name string
 }
 

--- a/bucket.go
+++ b/bucket.go
@@ -27,7 +27,7 @@ func init() {
 	BucketMetaSize = GetDiskSizeFromSingleObject(BucketMeta{})
 }
 
-// BucketMeta stores the meta info of a Bucket. E.g. the size of bucket it store in disk.
+// BucketMeta stores the Meta info of a Bucket. E.g. the size of bucket it store in disk.
 type BucketMeta struct {
 	Crc  uint32
 	Size uint32
@@ -36,7 +36,7 @@ type BucketMeta struct {
 
 // Bucket is the disk structure of bucket
 type Bucket struct {
-	meta *BucketMeta
+	Meta *BucketMeta
 	Id   uint64
 	Ds   Ds
 	Name string
@@ -59,12 +59,12 @@ func (b *Bucket) Encode() []byte {
 	binary.LittleEndian.PutUint16(buf[BucketMetaSize+IdSize:BucketMetaSize+IdSize+DsSize], uint16(b.Ds))
 	copy(buf[BucketMetaSize+IdSize:], b.Name)
 	c32 := crc32.ChecksumIEEE(buf[4:])
-	b.meta.Crc = c32
+	b.Meta.Crc = c32
 	return buf
 }
 
 func (b *Bucket) Decode(bytes []byte) error {
-	crc := b.meta.Crc
+	crc := b.Meta.Crc
 	crcInDisk := crc32.ChecksumIEEE(bytes[4:])
 	if crc != crcInDisk {
 		return ErrBucketCrcInvalid

--- a/bucket_manager.go
+++ b/bucket_manager.go
@@ -1,0 +1,99 @@
+package nutsdb
+
+import (
+	"errors"
+	"os"
+)
+
+var ErrBucketNotExist = errors.New("bucket not exist")
+
+const BucketStoreFileName = "bucket.meta"
+
+type Ds uint16
+type Id uint64
+type BucketName string
+
+type BucketManager struct {
+	fd               *os.File
+	BucketInfoMapper map[Id]*Bucket
+
+	BucketIDMarker map[BucketName]map[Ds]Id
+
+	// IDGenerator helps generates an ID for every single bucket
+	Gen *IDGenerator
+}
+
+func NewBucketManager(dir string) (*BucketManager, error) {
+	bm := &BucketManager{
+		BucketInfoMapper: map[Id]*Bucket{},
+		BucketIDMarker:   map[BucketName]map[Ds]Id{},
+	}
+	bucketFilePath := dir + "/" + BucketStoreFileName
+	_, err := os.Stat(bucketFilePath)
+	mode := os.O_RDWR
+	if err != nil {
+		mode |= os.O_CREATE
+	}
+	fd, err := os.OpenFile(bucketFilePath, mode, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	bm.fd = fd
+	bm.Gen = &IDGenerator{currentMaxId: 0}
+	return bm, nil
+}
+
+type bucketSubmitRequest struct {
+	ds     Ds
+	name   BucketName
+	bucket *Bucket
+}
+
+func (bm *BucketManager) SubmitPendingBucketChange(reqs []*bucketSubmitRequest) error {
+	bytes := make([]byte, 0)
+	for _, req := range reqs {
+		bs := req.bucket.Encode()
+		bytes = append(bytes, bs...)
+		bm.BucketInfoMapper[Id(req.bucket.Id)] = req.bucket
+		if _, exist := bm.BucketIDMarker[req.name]; !exist {
+			bm.BucketIDMarker[req.name] = map[Ds]Id{}
+		}
+		bm.BucketIDMarker[req.name][req.bucket.Ds] = Id(req.bucket.Id)
+	}
+	_, err := bm.fd.Write(bytes)
+	return err
+}
+
+type IDGenerator struct {
+	currentMaxId uint64
+}
+
+func (g *IDGenerator) GenId() uint64 {
+	g.currentMaxId++
+	return g.currentMaxId
+}
+
+func (bm *BucketManager) ExistBucket(ds Ds, name BucketName) bool {
+	bucket, err := bm.GetBucket(ds, name)
+	if bucket != nil && err == nil {
+		return true
+	}
+	return false
+}
+
+func (bm *BucketManager) GetBucket(ds Ds, name BucketName) (b *Bucket, err error) {
+	ds2IdMapper := bm.BucketIDMarker[name]
+	if ds2IdMapper == nil {
+		return nil, ErrBucketNotExist
+	}
+
+	if id, exist := ds2IdMapper[ds]; exist {
+		if bucket, ok := bm.BucketInfoMapper[id]; ok {
+			return bucket, nil
+		} else {
+			return nil, ErrBucketNotExist
+		}
+	} else {
+		return nil, ErrBucketNotExist
+	}
+}

--- a/bucket_manager.go
+++ b/bucket_manager.go
@@ -56,12 +56,12 @@ func (bm *BucketManager) SubmitPendingBucketChange(reqs []*bucketSubmitRequest) 
 		bs := req.bucket.Encode()
 		bytes = append(bytes, bs...)
 		// update the marker info
-		bm.BucketInfoMapper[Id(req.bucket.Id)] = req.bucket
 		if _, exist := bm.BucketIDMarker[req.name]; !exist {
 			bm.BucketIDMarker[req.name] = map[Ds]Id{}
 		}
 		switch req.bucket.Meta.Op {
 		case BucketInsertOperation:
+			bm.BucketInfoMapper[Id(req.bucket.Id)] = req.bucket
 			bm.BucketIDMarker[req.name][req.bucket.Ds] = Id(req.bucket.Id)
 		case BucketDeleteOperation:
 			if len(bm.BucketIDMarker[req.name]) == 1 {
@@ -69,7 +69,7 @@ func (bm *BucketManager) SubmitPendingBucketChange(reqs []*bucketSubmitRequest) 
 			} else {
 				delete(bm.BucketIDMarker[req.name], req.bucket.Ds)
 			}
-			bm.BucketInfoMapper[Id(req.bucket.Id)] = req.bucket
+			delete(bm.BucketInfoMapper, Id(req.bucket.Id))
 		}
 	}
 	_, err := bm.fd.Write(bytes)

--- a/bucket_manager.go
+++ b/bucket_manager.go
@@ -109,3 +109,19 @@ func (bm *BucketManager) GetBucket(ds Ds, name BucketName) (b *Bucket, err error
 		return nil, ErrBucketNotExist
 	}
 }
+
+func (bm *BucketManager) GetBucketById(id uint64) (*Bucket, error) {
+	if bucket, exist := bm.BucketInfoMapper[Id(id)]; exist {
+		return bucket, nil
+	} else {
+		return nil, ErrBucketNotExist
+	}
+}
+
+func (bm *BucketManager) GetBucketID(ds Ds, name BucketName) (uint64, error) {
+	if bucket, err := bm.GetBucket(ds, name); err != nil {
+		return 0, err
+	} else {
+		return bucket.Id, nil
+	}
+}

--- a/bucket_manager_test.go
+++ b/bucket_manager_test.go
@@ -83,7 +83,7 @@ func TestBucketManager_DeleteBucketIsolation(t *testing.T) {
 		txCreateBucket(t, db, DataStructureBTree, bucket1, nil)
 		txPut(t, db, bucket1, []byte("key_1"), []byte("value_1"), Persistent, nil, nil)
 		txDeleteBucket(t, db, DataStructureBTree, bucket1, nil)
-		txGet(t, db, bucket1, []byte("key_1"), nil, ErrBucketNotFound)
+		txGet(t, db, bucket1, []byte("key_1"), nil, ErrBucketNotExist)
 	})
 }
 

--- a/bucket_manager_test.go
+++ b/bucket_manager_test.go
@@ -1,0 +1,84 @@
+package nutsdb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBucketManager_NewBucketAndDeleteBucket(t *testing.T) {
+	bucket1 := "bucket_1"
+	bucket2 := "bucket_2"
+	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)
+		exist := db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket1))
+		assert.Equal(t, true, exist)
+		txNewBucket(t, db, bucket2, DataStructureBTree, nil, nil)
+		exist = db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket2))
+		assert.Equal(t, true, exist)
+	})
+
+	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)
+		exist := db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket1))
+		assert.Equal(t, true, exist)
+		txDeleteBucketFunc(t, db, bucket1, DataStructureBTree, nil, nil)
+		exist = db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket1))
+		assert.Equal(t, false, exist)
+	})
+}
+
+func TestBucketManager_ExistBucket(t *testing.T) {
+	bucket1 := "bucket_1"
+	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		exist := db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket1))
+		assert.Equal(t, false, exist)
+
+		txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)
+		exist = db.bm.ExistBucket(Ds(DataStructureBTree), BucketName(bucket1))
+		assert.Equal(t, true, exist)
+	})
+}
+
+func TestBucketManager_Recovery(t *testing.T) {
+	dir := "/tmp/nutsdb_test_data"
+	db, err := Open(DefaultOptions, WithDir(dir))
+	defer removeDir(dir)
+	assert.NotNil(t, db)
+	assert.Nil(t, err)
+	txNewBucket(t, db, "bucket_1", DataStructureBTree, nil, nil)
+	txNewBucket(t, db, "bucket_2", DataStructureBTree, nil, nil)
+	txDeleteBucketFunc(t, db, "bucket_1", DataStructureBTree, nil, nil)
+	db.Close()
+
+	db, err = Open(DefaultOptions, WithDir(dir))
+	assert.Nil(t, err)
+	assert.NotNil(t, db)
+
+	err = db.View(func(tx *Tx) error {
+		exist := tx.ExistBucket(DataStructureBTree, "bucket_2")
+		assert.Equal(t, true, exist)
+		exist = tx.ExistBucket(DataStructureBTree, "bucket_1")
+		assert.Equal(t, false, exist)
+		return nil
+	})
+	assert.Nil(t, err)
+}
+
+func txNewBucket(t *testing.T, db *DB, bucket string, ds uint16, expectErr error, finalExpectErr error) {
+	err := db.Update(func(tx *Tx) error {
+		success, err2 := tx.NewBucket(uint16(ds), bucket)
+		assert.Equal(t, true, success)
+		assertErr(t, expectErr, err2)
+		return nil
+	})
+	assertErr(t, err, finalExpectErr)
+}
+
+func txDeleteBucketFunc(t *testing.T, db *DB, bucket string, ds uint16, expectErr error, finalExpectErr error) {
+	err := db.Update(func(tx *Tx) error {
+		err2 := tx.DeleteBucket(uint16(ds), bucket)
+		assertErr(t, expectErr, err2)
+		return nil
+	})
+	assertErr(t, err, finalExpectErr)
+}

--- a/bucket_manager_test.go
+++ b/bucket_manager_test.go
@@ -41,13 +41,15 @@ func TestBucketManager_ExistBucket(t *testing.T) {
 
 func TestBucketManager_Recovery(t *testing.T) {
 	dir := "/tmp/nutsdb_test_data"
+	const bucket1 = "bucket_1"
+	const bucket2 = "bucket_2"
 	db, err := Open(DefaultOptions, WithDir(dir))
 	defer removeDir(dir)
 	assert.NotNil(t, db)
 	assert.Nil(t, err)
-	txNewBucket(t, db, "bucket_1", DataStructureBTree, nil, nil)
-	txNewBucket(t, db, "bucket_2", DataStructureBTree, nil, nil)
-	txDeleteBucketFunc(t, db, "bucket_1", DataStructureBTree, nil, nil)
+	txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)
+	txNewBucket(t, db, bucket2, DataStructureBTree, nil, nil)
+	txDeleteBucketFunc(t, db, bucket1, DataStructureBTree, nil, nil)
 	db.Close()
 
 	db, err = Open(DefaultOptions, WithDir(dir))
@@ -55,18 +57,39 @@ func TestBucketManager_Recovery(t *testing.T) {
 	assert.NotNil(t, db)
 
 	err = db.View(func(tx *Tx) error {
-		exist := tx.ExistBucket(DataStructureBTree, "bucket_2")
+		exist := tx.ExistBucket(DataStructureBTree, bucket2)
 		assert.Equal(t, true, exist)
-		exist = tx.ExistBucket(DataStructureBTree, "bucket_1")
+		exist = tx.ExistBucket(DataStructureBTree, bucket1)
 		assert.Equal(t, false, exist)
 		return nil
 	})
 	assert.Nil(t, err)
 }
 
+func TestBucketManager_DataStructureIsolation(t *testing.T) {
+	const bucket1 = "bucket_1"
+	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket1, nil)
+
+		assert.Equal(t, false, db.bm.ExistBucket(Ds(DataStructureList), bucket1))
+		assert.Equal(t, false, db.bm.ExistBucket(Ds(DataStructureSortedSet), bucket1))
+		assert.Equal(t, false, db.bm.ExistBucket(Ds(DataStructureSet), bucket1))
+	})
+}
+
+func TestBucketManager_DeleteBucketIsolation(t *testing.T) {
+	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		const bucket1 = "bucket_1"
+		txCreateBucket(t, db, DataStructureBTree, bucket1, nil)
+		txPut(t, db, bucket1, []byte("key_1"), []byte("value_1"), Persistent, nil, nil)
+		txDeleteBucket(t, db, DataStructureBTree, bucket1, nil)
+		txGet(t, db, bucket1, []byte("key_1"), nil, ErrBucketNotFound)
+	})
+}
+
 func txNewBucket(t *testing.T, db *DB, bucket string, ds uint16, expectErr error, finalExpectErr error) {
 	err := db.Update(func(tx *Tx) error {
-		success, err2 := tx.NewBucket(uint16(ds), bucket)
+		success, err2 := tx.NewBucket(ds, bucket)
 		assert.Equal(t, true, success)
 		assertErr(t, expectErr, err2)
 		return nil

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -18,7 +18,7 @@ func TestBucket_DecodeAndDecode(t *testing.T) {
 
 	bucketMeta := &BucketMeta{}
 	bucketMeta.Decode(bytes[:BucketMetaSize])
-	assert.Equal(t, bucketMeta.Op, BucketOperation(BucketInsertOperation))
+	assert.Equal(t, bucketMeta.Op, BucketInsertOperation)
 	assert.Equal(t, int64(8+2+8), int64(bucketMeta.Size))
 	decodeBucket := &Bucket{Meta: bucketMeta}
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1,0 +1,137 @@
+package nutsdb
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBucketMeta_Decode(t *testing.T) {
+	type fields struct {
+		Crc  uint32
+		Size uint32
+	}
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &BucketMeta{
+				Crc:  tt.fields.Crc,
+				Size: tt.fields.Size,
+			}
+			meta.Decode(tt.args.bytes)
+		})
+	}
+}
+
+func TestBucket_Decode(t *testing.T) {
+	type fields struct {
+		meta *BucketMeta
+		Id   uint64
+		Name string
+	}
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bucket{
+				meta: tt.fields.meta,
+				Id:   tt.fields.Id,
+				Name: tt.fields.Name,
+			}
+			tt.wantErr(t, b.Decode(tt.args.bytes), fmt.Sprintf("Decode(%v)", tt.args.bytes))
+		})
+	}
+}
+
+func TestBucket_Encode(t *testing.T) {
+	type fields struct {
+		meta *BucketMeta
+		Id   uint64
+		Name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []byte
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bucket{
+				meta: tt.fields.meta,
+				Id:   tt.fields.Id,
+				Name: tt.fields.Name,
+			}
+			assert.Equalf(t, tt.want, b.Encode(), "Encode()")
+		})
+	}
+}
+
+func TestBucket_GetEntrySize(t *testing.T) {
+	type fields struct {
+		meta *BucketMeta
+		Id   uint64
+		Name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bucket{
+				meta: tt.fields.meta,
+				Id:   tt.fields.Id,
+				Name: tt.fields.Name,
+			}
+			assert.Equalf(t, tt.want, b.GetEntrySize(), "GetEntrySize()")
+		})
+	}
+}
+
+func TestBucket_GetPayloadSize(t *testing.T) {
+	type fields struct {
+		meta *BucketMeta
+		Id   uint64
+		Name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bucket{
+				meta: tt.fields.meta,
+				Id:   tt.fields.Id,
+				Name: tt.fields.Name,
+			}
+			assert.Equalf(t, tt.want, b.GetPayloadSize(), "GetPayloadSize()")
+		})
+	}
+}

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -24,7 +24,7 @@ func TestBucket_DecodeAndDecode(t *testing.T) {
 
 	err := decodeBucket.Decode(bytes[BucketMetaSize:])
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(1), decodeBucket.Id)
+	assert.Equal(t, BucketId(1), decodeBucket.Id)
 	assert.Equal(t, decodeBucket.Name, "bucket_1")
 
 	crc := decodeBucket.GetCRC(bytes[:BucketMetaSize], bytes[BucketMetaSize:])

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -52,7 +52,7 @@ func TestBucket_Decode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Bucket{
-				meta: tt.fields.meta,
+				Meta: tt.fields.meta,
 				Id:   tt.fields.Id,
 				Name: tt.fields.Name,
 			}
@@ -77,7 +77,7 @@ func TestBucket_Encode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Bucket{
-				meta: tt.fields.meta,
+				Meta: tt.fields.meta,
 				Id:   tt.fields.Id,
 				Name: tt.fields.Name,
 			}
@@ -102,7 +102,7 @@ func TestBucket_GetEntrySize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Bucket{
-				meta: tt.fields.meta,
+				Meta: tt.fields.meta,
 				Id:   tt.fields.Id,
 				Name: tt.fields.Name,
 			}
@@ -127,7 +127,7 @@ func TestBucket_GetPayloadSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &Bucket{
-				meta: tt.fields.meta,
+				Meta: tt.fields.meta,
 				Id:   tt.fields.Id,
 				Name: tt.fields.Name,
 			}

--- a/datafile_test.go
+++ b/datafile_test.go
@@ -29,12 +29,11 @@ var (
 func init() {
 	filePath = "/tmp/foo"
 	entry = Entry{
-		Key:    []byte("key_0001"),
-		Value:  []byte("val_0001"),
-		Bucket: []byte("test_DataFile"),
+		Key:   []byte("key_0001"),
+		Value: []byte("val_0001"),
 		Meta: NewMetaData().WithKeySize(uint32(len("key_0001"))).
-			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).
-			WithBucketSize(uint32(len("test_datafile"))).WithFlag(DataSetFlag),
+			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).
+			WithTTL(Persistent).WithFlag(DataSetFlag).WithBucketId(1),
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -195,6 +195,10 @@ func open(opt Options) (*DB, error) {
 		return nil, fmt.Errorf("db.buildIndexes error: %s", err)
 	}
 
+	if err := db.rebuildBucketManager(); err != nil {
+		return nil, fmt.Errorf("db.rebuildBucketManager err:%s", err)
+	}
+
 	go db.mergeWorker()
 	go db.doWrites()
 	go db.tm.run()
@@ -939,4 +943,8 @@ func (db *DB) buildExpireCallback(bucket string, key []byte) func() {
 			log.Printf("occur error when expired deletion, error: %v", err.Error())
 		}
 	}
+}
+
+func (db *DB) rebuildBucketManager() error {
+	return nil
 }

--- a/db.go
+++ b/db.go
@@ -715,27 +715,6 @@ func (db *DB) buildIdxes(r *Record) error {
 	return nil
 }
 
-func (db *DB) buildNotDSIdxes(r *Record) error {
-	bucket, err := db.bm.GetBucketById(r.H.Meta.BucketId)
-	if err != nil {
-		return err
-	}
-	bucketId := bucket.Id
-	if r.H.Meta.Flag == DataSetBucketDeleteFlag {
-		db.deleteBucket(DataStructureSet, bucketId)
-	}
-	if r.H.Meta.Flag == DataSortedSetBucketDeleteFlag {
-		db.deleteBucket(DataStructureSortedSet, bucketId)
-	}
-	if r.H.Meta.Flag == DataBTreeBucketDeleteFlag {
-		db.deleteBucket(DataStructureBTree, bucketId)
-	}
-	if r.H.Meta.Flag == DataListBucketDeleteFlag {
-		db.deleteBucket(DataStructureList, bucketId)
-	}
-	return nil
-}
-
 func (db *DB) deleteBucket(ds uint16, bucket BucketId) {
 	if ds == DataStructureSet {
 		db.Index.set.delete(bucket)

--- a/db.go
+++ b/db.go
@@ -148,6 +148,7 @@ type (
 		writeCh          chan *request
 		tm               *ttlManager
 		RecordCount      int64 // current valid record count, exclude deleted, repeated
+		bm               *BucketManager
 	}
 )
 
@@ -183,6 +184,12 @@ func open(opt Options) (*DB, error) {
 	}
 
 	db.flock = fileLock
+
+	if bm, err := NewBucketManager(opt.Dir); err == nil {
+		db.bm = bm
+	} else {
+		return nil, err
+	}
 
 	if err := db.buildIndexes(); err != nil {
 		return nil, fmt.Errorf("db.buildIndexes error: %s", err)

--- a/db_error.go
+++ b/db_error.go
@@ -18,9 +18,6 @@ var (
 	// ErrDataStructureNotSupported is returned when pass a not supported data structure
 	ErrDataStructureNotSupported = errors.New("this data structure is not supported for now")
 
-	// ErrNotSupportHintBPTSparseIdxMode is returned not support mode `HintBPTSparseIdxMode`
-	ErrNotSupportHintBPTSparseIdxMode = errors.New("not support mode `HintBPTSparseIdxMode`")
-
 	// ErrDirLocked is returned when can't get the file lock of dir
 	ErrDirLocked = errors.New("the dir of db is locked")
 

--- a/db_test.go
+++ b/db_test.go
@@ -932,11 +932,6 @@ func TestDB_ChangeMode_RestartDB(t *testing.T) {
 			db, err = Open(opts)
 			require.NoError(t, err)
 
-			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-			txCreateBucket(t, db, DataStructureList, bucket, nil)
-			txCreateBucket(t, db, DataStructureSet, bucket, nil)
-			txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
-
 			// k-v
 			for i := 0; i < 10; i++ {
 				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)

--- a/entity_utils_test.go
+++ b/entity_utils_test.go
@@ -19,7 +19,7 @@ func TestGetDiskSizeFromSingleObject(t *testing.T) {
 			args: args{
 				obj: MetaData{},
 			},
-			want: 42,
+			want: 46,
 		},
 	}
 	for _, tt := range tests {

--- a/entry.go
+++ b/entry.go
@@ -24,7 +24,7 @@ import (
 	"github.com/xujiajun/utils/strconv2"
 )
 
-var payLoadSizeMismatchErr = errors.New("the payload size in meta mismatch with the payload size needed")
+var payLoadSizeMismatchErr = errors.New("the payload size in Meta mismatch with the payload size needed")
 
 type (
 	// Entry represents the data item.
@@ -43,7 +43,7 @@ type (
 		DataPos uint64
 	}
 
-	// MetaData represents the meta information of the data item.
+	// MetaData represents the Meta information of the data item.
 	MetaData struct {
 		KeySize    uint32
 		ValueSize  uint32
@@ -155,7 +155,7 @@ func (e *Entry) checkPayloadSize(size int64) error {
 	return nil
 }
 
-// ParseMeta parse meta object to entry
+// ParseMeta parse Meta object to entry
 func (e *Entry) ParseMeta(buf []byte) error {
 	e.Meta = NewMetaData().WithCrc(binary.LittleEndian.Uint32(buf[0:4])).
 		WithTimeStamp(binary.LittleEndian.Uint64(buf[4:12])).WithKeySize(binary.LittleEndian.Uint32(buf[12:16])).
@@ -241,7 +241,7 @@ func (e *Entry) WithValue(value []byte) *Entry {
 	return e
 }
 
-// WithMeta set meta to Entry
+// WithMeta set Meta to Entry
 func (e *Entry) WithMeta(meta *MetaData) *Entry {
 	e.Meta = meta
 	return e

--- a/entry_test.go
+++ b/entry_test.go
@@ -31,14 +31,12 @@ type EntryTestSuite struct {
 
 func (suite *EntryTestSuite) SetupSuite() {
 	suite.entry = Entry{
-		Key:    []byte("key_0001"),
-		Value:  []byte("val_0001"),
-		Bucket: []byte("test_entry"),
+		Key:   []byte("key_0001"),
+		Value: []byte("val_0001"),
 		Meta: NewMetaData().WithKeySize(uint32(len("key_0001"))).
-			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).
-			WithBucketSize(uint32(len("test_entry"))).WithFlag(DataSetFlag),
+			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).WithFlag(DataSetFlag).WithBucketId(1),
 	}
-	suite.expectedEncode = []byte{48, 176, 185, 16, 1, 38, 64, 92, 0, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 101, 115, 116, 95, 101, 110, 116, 114, 121, 107, 101, 121, 95, 48, 48, 48, 49, 118, 97, 108, 95, 48, 48, 48, 49}
+	suite.expectedEncode = []byte{228, 252, 145, 200, 1, 38, 64, 92, 0, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 107, 101, 121, 95, 48, 48, 48, 49, 118, 97, 108, 95, 48, 48, 48, 49}
 }
 
 func (suite *EntryTestSuite) TestEncode() {
@@ -56,7 +54,7 @@ func (suite *EntryTestSuite) TestIsZero() {
 
 func (suite *EntryTestSuite) TestGetCrc() {
 
-	crc1 := suite.entry.GetCrc(suite.expectedEncode[:42])
+	crc1 := suite.entry.GetCrc(suite.expectedEncode[:DataEntryHeaderSize])
 	crc2 := binary.LittleEndian.Uint32(suite.expectedEncode[:4])
 
 	if crc1 != crc2 {

--- a/errors_test.go
+++ b/errors_test.go
@@ -145,7 +145,6 @@ func TestIsDBClosed(t *testing.T) {
 }
 
 func TestIsPrefixScan(t *testing.T) {
-	t.Skip()
 	bucket := "test_prefix_scan"
 	t.Run("if prefix scanning not found the result return true", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -149,8 +149,8 @@ func TestIsPrefixScan(t *testing.T) {
 	t.Run("if prefix scanning not found the result return true", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			{
-				tx, err := db.Begin(true)
 				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+				tx, err := db.Begin(true)
 				require.NoError(t, err)
 				for i := 0; i <= 10; i++ {
 					key := []byte("key_" + fmt.Sprintf("%07d", i))

--- a/errors_test.go
+++ b/errors_test.go
@@ -124,6 +124,8 @@ func TestIsDBClosed(t *testing.T) {
 	db, err = Open(opt)
 
 	t.Run("db can be used before closed", func(t *testing.T) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		err = db.Update(
 			func(tx *Tx) error {
 				return tx.Put(bucket, key, val, Persistent)
@@ -148,6 +150,7 @@ func TestIsPrefixScan(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			{
 				tx, err := db.Begin(true)
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 				require.NoError(t, err)
 				for i := 0; i <= 10; i++ {
 					key := []byte("key_" + fmt.Sprintf("%07d", i))
@@ -187,6 +190,8 @@ func TestIsPrefixSearchScan(t *testing.T) {
 	t.Run("if prefix and search scanning not found the result return true", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			{
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 				tx, err := db.Begin(true)
 				require.NoError(t, err)
 				for i := 0; i <= 10; i++ {

--- a/errors_test.go
+++ b/errors_test.go
@@ -145,6 +145,7 @@ func TestIsDBClosed(t *testing.T) {
 }
 
 func TestIsPrefixScan(t *testing.T) {
+	t.Skip()
 	bucket := "test_prefix_scan"
 	t.Run("if prefix scanning not found the result return true", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {

--- a/index.go
+++ b/index.go
@@ -19,39 +19,29 @@ type IdxType interface {
 }
 
 type defaultOp[T IdxType] struct {
-	idx map[string]*T
+	idx map[BucketId]*T
 }
 
-func (op *defaultOp[T]) computeIfAbsent(bucket string, f func() *T) *T {
-	if i, isExist := op.idx[bucket]; isExist {
+func (op *defaultOp[T]) computeIfAbsent(id BucketId, f func() *T) *T {
+	if i, isExist := op.idx[id]; isExist {
 		return i
 	}
 	i := f()
-	op.idx[bucket] = i
+	op.idx[id] = i
 	return i
 }
 
-func (op *defaultOp[T]) delete(bucket string) {
-	delete(op.idx, bucket)
+func (op *defaultOp[T]) delete(id BucketId) {
+	delete(op.idx, id)
 }
 
-func (op *defaultOp[T]) exist(bucket string) (*T, bool) {
-	i, isExist := op.idx[bucket]
+func (op *defaultOp[T]) exist(id BucketId) (*T, bool) {
+	i, isExist := op.idx[id]
 	return i, isExist
 }
 
 func (op *defaultOp[T]) getIdxLen() int {
 	return len(op.idx)
-}
-
-func (op *defaultOp[T]) handleIdxBucket(f func(bucket string) error) error {
-	for bucket := range op.idx {
-		err := f(bucket)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (op *defaultOp[T]) rangeIdx(f func(elem *T)) {
@@ -64,8 +54,8 @@ type ListIdx struct {
 	*defaultOp[List]
 }
 
-func (idx ListIdx) getWithDefault(bucket string) *List {
-	return idx.defaultOp.computeIfAbsent(bucket, func() *List {
+func (idx ListIdx) getWithDefault(id BucketId) *List {
+	return idx.defaultOp.computeIfAbsent(id, func() *List {
 		return NewList()
 	})
 }
@@ -74,8 +64,8 @@ type BTreeIdx struct {
 	*defaultOp[BTree]
 }
 
-func (idx BTreeIdx) getWithDefault(bucket string) *BTree {
-	return idx.defaultOp.computeIfAbsent(bucket, func() *BTree {
+func (idx BTreeIdx) getWithDefault(id BucketId) *BTree {
+	return idx.defaultOp.computeIfAbsent(id, func() *BTree {
 		return NewBTree()
 	})
 }
@@ -84,8 +74,8 @@ type SetIdx struct {
 	*defaultOp[Set]
 }
 
-func (idx SetIdx) getWithDefault(bucket string) *Set {
-	return idx.defaultOp.computeIfAbsent(bucket, func() *Set {
+func (idx SetIdx) getWithDefault(id BucketId) *Set {
+	return idx.defaultOp.computeIfAbsent(id, func() *Set {
 		return NewSet()
 	})
 }
@@ -94,8 +84,8 @@ type SortedSetIdx struct {
 	*defaultOp[SortedSet]
 }
 
-func (idx SortedSetIdx) getWithDefault(bucket string, db *DB) *SortedSet {
-	return idx.defaultOp.computeIfAbsent(bucket, func() *SortedSet {
+func (idx SortedSetIdx) getWithDefault(id BucketId, db *DB) *SortedSet {
+	return idx.defaultOp.computeIfAbsent(id, func() *SortedSet {
 		return NewSortedSet(db)
 	})
 }
@@ -109,9 +99,9 @@ type index struct {
 
 func newIndex() *index {
 	i := new(index)
-	i.list = ListIdx{&defaultOp[List]{idx: map[string]*List{}}}
-	i.bTree = BTreeIdx{&defaultOp[BTree]{idx: map[string]*BTree{}}}
-	i.set = SetIdx{&defaultOp[Set]{idx: map[string]*Set{}}}
-	i.sortedSet = SortedSetIdx{&defaultOp[SortedSet]{idx: map[string]*SortedSet{}}}
+	i.list = ListIdx{&defaultOp[List]{idx: map[BucketId]*List{}}}
+	i.bTree = BTreeIdx{&defaultOp[BTree]{idx: map[BucketId]*BTree{}}}
+	i.set = SetIdx{&defaultOp[Set]{idx: map[BucketId]*Set{}}}
+	i.sortedSet = SortedSetIdx{&defaultOp[SortedSet]{idx: map[BucketId]*SortedSet{}}}
 	return i
 }

--- a/iterator.go
+++ b/iterator.go
@@ -29,10 +29,14 @@ type IteratorOptions struct {
 }
 
 func NewIterator(tx *Tx, bucket string, options IteratorOptions) *Iterator {
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil
+	}
 	iterator := &Iterator{
 		tx:      tx,
 		options: options,
-		iter:    tx.db.Index.bTree.getWithDefault(bucket).btree.Iter(),
+		iter:    tx.db.Index.bTree.getWithDefault(b.Id).btree.Iter(),
 	}
 
 	if options.Reverse {

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -23,6 +23,8 @@ func TestIterator(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		for i := 0; i < 100; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
 		}
@@ -51,6 +53,8 @@ func TestIterator_Reverse(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		for i := 0; i < 100; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
 		}
@@ -78,6 +82,8 @@ func TestIterator_Seek(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		for i := 0; i < 100; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
 		}

--- a/list_test.go
+++ b/list_test.go
@@ -243,7 +243,6 @@ func TestList_LRemByIndex(t *testing.T) {
 }
 
 func generateRecords(count int) []*Record {
-	bucket := []byte("bucket")
 	rand.Seed(time.Now().UnixNano())
 	records := make([]*Record, count)
 	for i := 0; i < count; i++ {
@@ -251,16 +250,16 @@ func generateRecords(count int) []*Record {
 		val := GetRandomBytes(24)
 
 		metaData := &MetaData{
-			KeySize:    uint32(len(key)),
-			ValueSize:  uint32(len(val)),
-			Timestamp:  uint64(time.Now().Unix()),
-			TTL:        uint32(rand.Intn(3600)),
-			Flag:       uint16(rand.Intn(2)),
-			BucketSize: uint32(len(bucket)),
-			TxID:       uint64(rand.Intn(1000)),
-			Status:     uint16(rand.Intn(2)),
-			Ds:         uint16(rand.Intn(3)),
-			Crc:        rand.Uint32(),
+			KeySize:   uint32(len(key)),
+			ValueSize: uint32(len(val)),
+			Timestamp: uint64(time.Now().Unix()),
+			TTL:       uint32(rand.Intn(3600)),
+			Flag:      uint16(rand.Intn(2)),
+			TxID:      uint64(rand.Intn(1000)),
+			Status:    uint16(rand.Intn(2)),
+			Ds:        uint16(rand.Intn(3)),
+			Crc:       rand.Uint32(),
+			BucketId:  1,
 		}
 
 		record := &Record{
@@ -270,8 +269,7 @@ func generateRecords(count int) []*Record {
 				Meta:    metaData,
 				DataPos: uint64(rand.Uint32()),
 			},
-			V:      val,
-			Bucket: string(bucket),
+			V: val,
 		}
 		records[i] = record
 	}

--- a/merge_test.go
+++ b/merge_test.go
@@ -100,7 +100,9 @@ func TestDB_MergeForSet(t *testing.T) {
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
-		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+		if exist := db.bm.ExistBucket(Ds(DataStructureSet), BucketName(bucket)); !exist {
+			txCreateBucket(t, db, DataStructureSet, bucket, nil)
+		}
 
 		require.NoError(t, err)
 
@@ -197,8 +199,9 @@ func TestDB_MergeForZSet(t *testing.T) {
 
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
-		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
+		if exist := db.bm.ExistBucket(Ds(DataStructureSortedSet), BucketName(bucket)); !exist {
+			txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+		}
 		require.NoError(t, err)
 
 		// add items
@@ -298,7 +301,9 @@ func TestDB_MergeForList(t *testing.T) {
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
-		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+		if exist := db.bm.ExistBucket(Ds(DataStructureList), BucketName(bucket)); !exist {
+			txCreateBucket(t, db, DataStructureList, bucket, nil)
+		}
 
 		require.NoError(t, err)
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -31,6 +31,7 @@ func TestDB_MergeForString(t *testing.T) {
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 		require.NoError(t, err)
 
 		// Merge is not needed
@@ -99,6 +100,8 @@ func TestDB_MergeForSet(t *testing.T) {
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		require.NoError(t, err)
 
 		// Merge is not needed
@@ -191,8 +194,11 @@ func TestDB_MergeForZSet(t *testing.T) {
 
 	// test different EntryIdxMode
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		require.NoError(t, err)
 
 		// add items
@@ -292,6 +298,8 @@ func TestDB_MergeForList(t *testing.T) {
 	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
 		opts.EntryIdxMode = idxMode
 		db, err := Open(opts)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		require.NoError(t, err)
 
 		// check that we don't need merge

--- a/record.go
+++ b/record.go
@@ -20,9 +20,8 @@ import (
 
 // Record records entry and hint.
 type Record struct {
-	H      *Hint
-	V      []byte
-	Bucket string
+	H *Hint
+	V []byte
 }
 
 // IsExpired returns the record if expired or not.
@@ -65,11 +64,5 @@ func (r *Record) WithHint(hint *Hint) *Record {
 // WithValue set the Value to Record
 func (r *Record) WithValue(v []byte) *Record {
 	r.V = v
-	return r
-}
-
-// WithBucket set the Bucket to Record
-func (r *Record) WithBucket(bucket string) *Record {
-	r.Bucket = bucket
 	return r
 }

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -62,6 +62,33 @@ func (fr *fileRecovery) readEntry() (e *Entry, err error) {
 	return e, nil
 }
 
+func (fr *fileRecovery) readBucket() (b *Bucket, err error) {
+	buf := make([]byte, BucketMetaSize)
+	_, err = io.ReadFull(fr.reader, buf)
+	if err != nil {
+		return nil, err
+	}
+	meta := new(BucketMeta)
+	meta.Decode(buf)
+	bucket := new(Bucket)
+	bucket.Meta = meta
+	dataBuf := make([]byte, meta.Size)
+	_, err = io.ReadFull(fr.reader, dataBuf)
+	if err != nil {
+		return nil, err
+	}
+	err = bucket.Decode(dataBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	if bucket.GetCRC(buf, dataBuf) != bucket.Meta.Crc {
+		return nil, ErrBucketCrcInvalid
+	}
+
+	return bucket, nil
+}
+
 // calBufferSize calculates the buffer size of bufio.Reader
 // if the size < 4 * KB, use 4 * KB as the size of buffer in bufio.Reader
 // if the size > 4 * KB, use the nearly blockSize buffer as the size of buffer in bufio.Reader

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -63,6 +63,6 @@ func Test_fileRecovery_readBucket(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, readBucket.Meta.Op, BucketInsertOperation)
 	assert.Equal(t, int64(8+2+8), int64(readBucket.Meta.Size))
-	assert.Equal(t, uint64(1), readBucket.Id)
+	assert.Equal(t, BucketId(1), readBucket.Id)
 	assert.Equal(t, readBucket.Name, "bucket_1")
 }

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -61,7 +61,7 @@ func Test_fileRecovery_readBucket(t *testing.T) {
 	assert.Nil(t, err)
 	readBucket, err := fr.readBucket()
 	assert.Nil(t, err)
-	assert.Equal(t, readBucket.Meta.Op, BucketOperation(BucketInsertOperation))
+	assert.Equal(t, readBucket.Meta.Op, BucketInsertOperation)
 	assert.Equal(t, int64(8+2+8), int64(readBucket.Meta.Size))
 	assert.Equal(t, uint64(1), readBucket.Id)
 	assert.Equal(t, readBucket.Name, "bucket_1")

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -13,10 +13,10 @@ func Test_readEntry(t *testing.T) {
 	fd, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_RDWR, os.ModePerm)
 	require.NoError(t, err)
 	meta := NewMetaData().WithKeySize(uint32(len("key"))).
-		WithValueSize(uint32(len("val"))).WithTimeStamp(1547707905).WithTTL(Persistent).
-		WithBucketSize(uint32(len("Test_readEntry"))).WithFlag(DataSetFlag)
+		WithValueSize(uint32(len("val"))).WithTimeStamp(1547707905).
+		WithTTL(Persistent).WithFlag(DataSetFlag).WithBucketId(1)
 
-	expect := NewEntry().WithKey([]byte("key")).WithMeta(meta).WithValue([]byte("val")).WithBucket([]byte("Test_readEntry"))
+	expect := NewEntry().WithKey([]byte("key")).WithMeta(meta).WithValue([]byte("val"))
 
 	_, err = fd.Write(expect.Encode())
 	require.NoError(t, err)

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -33,3 +33,33 @@ func Test_readEntry(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func Test_fileRecovery_readBucket(t *testing.T) {
+	filePath := "bucket_test_data"
+	bucket := &Bucket{
+		Meta: &BucketMeta{
+			Op: BucketInsertOperation,
+		},
+		Id:   1,
+		Ds:   Ds(DataStructureBTree),
+		Name: "bucket_1",
+	}
+	bytes := bucket.Encode()
+
+	fd, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	defer func() {
+		fd.Close()
+		os.Remove(filePath)
+	}()
+	assert.Nil(t, err)
+	_, err = fd.Write(bytes)
+	assert.Nil(t, err)
+
+	fr, err := newFileRecovery(filePath, 4*MB)
+	readBucket, err := fr.readBucket()
+	assert.Nil(t, err)
+	assert.Equal(t, readBucket.Meta.Op, BucketOperation(BucketInsertOperation))
+	assert.Equal(t, int64(8+2+8), int64(readBucket.Meta.Size))
+	assert.Equal(t, uint64(1), readBucket.Id)
+	assert.Equal(t, readBucket.Name, "bucket_1")
+}

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -48,14 +48,17 @@ func Test_fileRecovery_readBucket(t *testing.T) {
 
 	fd, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
 	defer func() {
-		fd.Close()
-		os.Remove(filePath)
+		err = fd.Close()
+		assert.Nil(t, err)
+		err = os.Remove(filePath)
+		assert.Nil(t, nil)
 	}()
 	assert.Nil(t, err)
 	_, err = fd.Write(bytes)
 	assert.Nil(t, err)
 
 	fr, err := newFileRecovery(filePath, 4*MB)
+	assert.Nil(t, err)
 	readBucket, err := fr.readBucket()
 	assert.Nil(t, err)
 	assert.Equal(t, readBucket.Meta.Op, BucketOperation(BucketInsertOperation))

--- a/ttl_manager.go
+++ b/ttl_manager.go
@@ -26,10 +26,10 @@ func newNodesInBucket() nodesInBucket {
 	return make(map[string]timer.TimeNoder)
 }
 
-type nodes map[string]nodesInBucket // bucket to nodes that in a bucket
+type nodes map[BucketId]nodesInBucket // bucket to nodes that in a bucket
 
-func (n nodes) getNode(bucket, key string) (timer.TimeNoder, bool) {
-	nib, ok := n[bucket]
+func (n nodes) getNode(bucketId BucketId, key string) (timer.TimeNoder, bool) {
+	nib, ok := n[bucketId]
 	if !ok {
 		return nil, false
 	}
@@ -37,17 +37,17 @@ func (n nodes) getNode(bucket, key string) (timer.TimeNoder, bool) {
 	return node, ok
 }
 
-func (n nodes) addNode(bucket, key string, node timer.TimeNoder) {
-	nib, ok := n[bucket]
+func (n nodes) addNode(bucketId BucketId, key string, node timer.TimeNoder) {
+	nib, ok := n[bucketId]
 	if !ok {
 		nib = newNodesInBucket()
-		n[bucket] = nib
+		n[bucketId] = nib
 	}
 	nib[key] = node
 }
 
-func (n nodes) delNode(bucket, key string) {
-	if nib, ok := n[bucket]; ok {
+func (n nodes) delNode(bucketId BucketId, key string) {
+	if nib, ok := n[bucketId]; ok {
 		delete(nib, key)
 	}
 }
@@ -79,21 +79,21 @@ func (tm *ttlManager) run() {
 	tm.t.Run()
 }
 
-func (tm *ttlManager) exist(bucket, key string) bool {
-	_, ok := tm.timerNodes.getNode(bucket, key)
+func (tm *ttlManager) exist(bucketId BucketId, key string) bool {
+	_, ok := tm.timerNodes.getNode(bucketId, key)
 	return ok
 }
 
-func (tm *ttlManager) add(bucket, key string, expire time.Duration, callback func()) {
-	if node, ok := tm.timerNodes.getNode(bucket, key); ok {
+func (tm *ttlManager) add(bucketId BucketId, key string, expire time.Duration, callback func()) {
+	if node, ok := tm.timerNodes.getNode(bucketId, key); ok {
 		node.Stop()
 	}
 
 	node := tm.t.AfterFunc(expire, callback)
-	tm.timerNodes.addNode(bucket, key, node)
+	tm.timerNodes.addNode(bucketId, key, node)
 }
 
-func (tm *ttlManager) del(bucket, key string) {
+func (tm *ttlManager) del(bucket BucketId, key string) {
 	tm.timerNodes.delNode(bucket, key)
 }
 

--- a/tx.go
+++ b/tx.go
@@ -275,7 +275,7 @@ func (tx *Tx) Commit() (err error) {
 	tx.db.RecordCount += curWriteCount
 
 	if err := tx.DeleteBucketInIndex(); err != nil {
-
+		return err
 	}
 
 	return nil
@@ -719,7 +719,7 @@ func (tx *Tx) buildIdxes(records []*Record) error {
 
 		switch meta.Ds {
 		case DataStructureBTree:
-			tx.db.buildBTreeIdx(record)
+			err = tx.db.buildBTreeIdx(record)
 		case DataStructureList:
 			err = tx.db.buildListIdx(record)
 		case DataStructureSet:

--- a/tx.go
+++ b/tx.go
@@ -784,7 +784,7 @@ func (tx *Tx) DeleteBucketInIndex() error {
 				case Ds(DataStructureSortedSet):
 					tx.db.Index.sortedSet.delete(bucket.Name)
 				default:
-					return errors.New("unsupported data structure")
+					return ErrDataStructureNotSupported
 				}
 			}
 		}

--- a/tx_btree.go
+++ b/tx_btree.go
@@ -36,15 +36,21 @@ func (tx *Tx) Get(bucket string, key []byte) (e *Entry, err error) {
 	}
 
 	idxMode := tx.db.opt.EntryIdxMode
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketName := b.Name
+	bucketId := b.Id
 
-	if idx, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if idx, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		r, found := idx.Find(key)
 		if !found {
 			return nil, ErrKeyNotFound
 		}
 
 		if r.IsExpired() {
-			tx.putDeleteLog(bucket, key, nil, Persistent, DataDeleteFlag, uint64(time.Now().Unix()), DataStructureBTree)
+			tx.putDeleteLog(bucketId, key, nil, Persistent, DataDeleteFlag, uint64(time.Now().Unix()), DataStructureBTree)
 			return nil, ErrNotFoundKey
 		}
 
@@ -63,7 +69,7 @@ func (tx *Tx) Get(bucket string, key []byte) (e *Entry, err error) {
 		return nil, ErrNotFoundBucket
 	}
 
-	return nil, ErrBucketAndKey(bucket, key)
+	return nil, ErrBucketAndKey(bucketName, key)
 }
 
 // GetAll returns all keys and values of the bucket stored at given bucket.
@@ -73,8 +79,13 @@ func (tx *Tx) GetAll(bucket string) (entries Entries, err error) {
 	}
 
 	entries = Entries{}
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
 
-	if index, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if index, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		records := index.All()
 		if len(records) == 0 {
 			return nil, ErrBucketEmpty
@@ -98,8 +109,13 @@ func (tx *Tx) RangeScan(bucket string, start, end []byte) (es Entries, err error
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
 
-	if index, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if index, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		records := index.Range(start, end)
 		if err != nil {
 			return nil, ErrRangeScan
@@ -124,8 +140,13 @@ func (tx *Tx) PrefixScan(bucket string, prefix []byte, offsetNum int, limitNum i
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
 
-	if idx, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if idx, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		records := idx.PrefixScan(prefix, offsetNum, limitNum)
 		es, err = tx.getHintIdxDataItemsWrapper(records, limitNum, es)
 		if err != nil {
@@ -146,8 +167,13 @@ func (tx *Tx) PrefixSearchScan(bucket string, prefix []byte, reg string, offsetN
 	if err := tx.checkTxIsClosed(); err != nil {
 		return nil, err
 	}
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
 
-	if idx, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if idx, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		records := idx.PrefixSearchScan(prefix, reg, offsetNum, limitNum)
 		es, err = tx.getHintIdxDataItemsWrapper(records, limitNum, es)
 		if err != nil {
@@ -167,8 +193,13 @@ func (tx *Tx) Delete(bucket string, key []byte) error {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return err
 	}
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureBTree), BucketName(bucket))
+	if err != nil {
+		return err
+	}
+	bucketId := b.Id
 
-	if idx, ok := tx.db.Index.bTree.exist(bucket); ok {
+	if idx, ok := tx.db.Index.bTree.exist(bucketId); ok {
 		if _, found := idx.Find(key); !found {
 			return ErrKeyNotFound
 		}
@@ -187,7 +218,7 @@ func (tx *Tx) getHintIdxDataItemsWrapper(records []*Record, limitNum int, es Ent
 			return nil, err
 		}
 		if r.IsExpired() {
-			tx.putDeleteLog(bucket.Name, r.H.Key, nil, Persistent, DataDeleteFlag, uint64(time.Now().Unix()), DataStructureBTree)
+			tx.putDeleteLog(bucket.Id, r.H.Key, nil, Persistent, DataDeleteFlag, uint64(time.Now().Unix()), DataStructureBTree)
 			continue
 		}
 		if limitNum > 0 && len(es) < limitNum || limitNum == ScanNoLimit {

--- a/tx_btree_test.go
+++ b/tx_btree_test.go
@@ -37,6 +37,8 @@ func TestTx_PutAndGet(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 
 			{
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 				tx, err := db.Begin(true)
 				require.NoError(t, err)
 

--- a/tx_btree_test.go
+++ b/tx_btree_test.go
@@ -97,7 +97,7 @@ func TestTx_GetAll(t *testing.T) {
 
 			{
 				// setup the data
-
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 				tx, err := db.Begin(true)
 				require.NoError(t, err)
 
@@ -145,6 +145,7 @@ func TestTx_RangeScan_Err(t *testing.T) {
 
 		{
 			// setup the data
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
@@ -182,6 +183,7 @@ func TestTx_RangeScan(t *testing.T) {
 
 		{
 			// setup the data
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
@@ -239,7 +241,7 @@ func TestTx_PrefixScan(t *testing.T) {
 
 		{
 			// setup the data
-
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
 
@@ -287,6 +289,8 @@ func TestTx_PrefixSearchScan(t *testing.T) {
 	bucket := "bucket_for_prefix_search_scan"
 
 	withDefaultDB(t, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		regs := "1"
 
 		tx, err := db.Begin(true)
@@ -337,6 +341,7 @@ func TestTx_DeleteAndGet(t *testing.T) {
 		bucket := "bucket_delete_test"
 
 		{
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
 
@@ -374,6 +379,7 @@ func TestTx_DeleteAndGet(t *testing.T) {
 func TestTx_DeleteFromMemory(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		bucket := "bucket"
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
 		for i := 0; i < 10; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
@@ -401,6 +407,8 @@ func TestTx_GetAndScansFromHintKey(t *testing.T) {
 
 	bucket := "bucket_get_test"
 	withRAMIdxDB(t, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		// write tx begin
 		tx, err := db.Begin(true)
 		require.NoError(t, err)
@@ -457,6 +465,8 @@ func TestTx_Put_Err(t *testing.T) {
 	t.Run("write with read only tx", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			// write tx begin err setting here
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			tx, err := db.Begin(false) // tx not writable
 			require.NoError(t, err)
 
@@ -471,6 +481,8 @@ func TestTx_Put_Err(t *testing.T) {
 
 	t.Run("write with empty key", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
 
@@ -485,6 +497,7 @@ func TestTx_Put_Err(t *testing.T) {
 
 	t.Run("write with TOO big size", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 			tx, err := db.Begin(true)
 			require.NoError(t, err)
 
@@ -505,6 +518,8 @@ func TestTx_Put_Err(t *testing.T) {
 func TestTx_PrefixScan_NotFound(t *testing.T) {
 	t.Run("prefix scan in empty bucket", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			tx, err := db.Begin(false)
 			assert.NoError(t, err)
 
@@ -522,6 +537,7 @@ func TestTx_PrefixScan_NotFound(t *testing.T) {
 
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			{ // write tx begin
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
 				tx, err := db.Begin(true)
 				require.NoError(t, err)
@@ -578,6 +594,8 @@ func TestTx_PrefixSearchScan_NotFound(t *testing.T) {
 
 	t.Run("prefix search in empty bucket", func(t *testing.T) {
 		withDefaultDB(t, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			tx, err := db.Begin(false)
 			require.NoError(t, err)
 
@@ -593,6 +611,8 @@ func TestTx_PrefixSearchScan_NotFound(t *testing.T) {
 
 		withDefaultDB(t, func(t *testing.T, db *DB) {
 			{ // set up the data
+				txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 				tx, err = db.Begin(true) // write tx begin
 				require.NoError(t, err)
 
@@ -636,6 +656,8 @@ func TestTx_RangeScan_NotFound(t *testing.T) {
 	bucket := "bucket_range_scan_test"
 
 	withDefaultDB(t, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 		tx, err := db.Begin(true) // write tx begin
 		require.NoError(t, err)
 
@@ -664,6 +686,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 
 	t.Run("expired deletion", func(t *testing.T) {
 		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), 1, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(1), GetTestBytes(1), 2, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(2), GetTestBytes(2), 3, nil, nil)
@@ -697,6 +721,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 
 	t.Run("update expire time", func(t *testing.T) {
 		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), 1, nil, nil)
 			time.Sleep(500 * time.Millisecond)
 
@@ -712,6 +738,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 
 	t.Run("persist expire time", func(t *testing.T) {
 		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), 1, nil, nil)
 			time.Sleep(500 * time.Millisecond)
 
@@ -728,6 +756,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 	t.Run("expired deletion when open", func(t *testing.T) {
 		opts := DefaultOptions
 		runNutsDBTest(t, &opts, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), 1, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(1), GetTestBytes(1), 3, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(2), GetTestBytes(2), 3, nil, nil)
@@ -767,6 +797,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 		opts.SegmentSize = 1 * 100
 		runNutsDBTest(t, &opts, func(t *testing.T, db *DB) {
 			bucket := "bucket"
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), Persistent, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(1), GetTestBytes(1), Persistent, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(2), GetTestBytes(2), 1, nil, nil)
@@ -789,6 +821,7 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 		opts := DefaultOptions
 		opts.ExpiredDeleteType = TimeHeap
 		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 			txPut(t, db, bucket, GetTestBytes(0), GetTestBytes(0), 1, nil, nil)
 			txPut(t, db, bucket, GetTestBytes(1), GetTestBytes(1), 2, nil, nil)
 			txGet(t, db, bucket, GetTestBytes(0), GetTestBytes(0), nil)

--- a/tx_btree_test.go
+++ b/tx_btree_test.go
@@ -392,7 +392,7 @@ func TestTx_DeleteFromMemory(t *testing.T) {
 		txDel(t, db, bucket, GetTestBytes(3), nil)
 
 		err := db.View(func(tx *Tx) error {
-			r, ok := db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(3))
+			r, ok := db.Index.bTree.getWithDefault(1).Find(GetTestBytes(3))
 			require.Nil(t, r)
 			require.False(t, ok)
 
@@ -709,11 +709,11 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 			// this entry will be deleted
 			txGet(t, db, bucket, GetTestBytes(1), nil, ErrKeyNotFound)
 
-			r, ok := db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(0))
+			r, ok := db.Index.bTree.getWithDefault(1).Find(GetTestBytes(0))
 			require.Nil(t, r)
 			require.False(t, ok)
 
-			r, ok = db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(1))
+			r, ok = db.Index.bTree.getWithDefault(1).Find(GetTestBytes(1))
 			require.Nil(t, r)
 			require.False(t, ok)
 		})
@@ -811,7 +811,7 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 			txGet(t, db, bucket, GetTestBytes(1), GetTestBytes(1), nil)
 			txGet(t, db, bucket, GetTestBytes(2), nil, ErrKeyNotFound)
 
-			r, ok := db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(2))
+			r, ok := db.Index.bTree.getWithDefault(1).Find(GetTestBytes(2))
 			require.Nil(t, r)
 			require.False(t, ok)
 		})
@@ -839,11 +839,11 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 			// this entry will be deleted
 			txGet(t, db, bucket, GetTestBytes(1), nil, ErrKeyNotFound)
 
-			r, ok := db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(0))
+			r, ok := db.Index.bTree.getWithDefault(1).Find(GetTestBytes(0))
 			require.Nil(t, r)
 			require.False(t, ok)
 
-			r, ok = db.Index.bTree.getWithDefault(bucket).Find(GetTestBytes(1))
+			r, ok = db.Index.bTree.getWithDefault(1).Find(GetTestBytes(1))
 			require.Nil(t, r)
 			require.False(t, ok)
 		})

--- a/tx_bucket.go
+++ b/tx_bucket.go
@@ -47,12 +47,15 @@ func (tx *Tx) NewBucket(ds uint16, name string) (success bool, err error) {
 		return false, ErrBucketAlreadyExist
 	}
 	bucket := &Bucket{
-		meta: &BucketMeta{
+		Meta: &BucketMeta{
 			Op: BucketInsertOperation,
 		},
 		Id:   tx.db.bm.Gen.GenId(),
 		Ds:   Ds(ds),
 		Name: name,
+	}
+	if _, exist := tx.pendingBucketList[Ds(ds)]; !exist {
+		tx.pendingBucketList[Ds(ds)] = map[BucketName]*Bucket{}
 	}
 	tx.pendingBucketList[Ds(ds)][BucketName(name)] = bucket
 	return true, nil
@@ -70,7 +73,7 @@ func (tx *Tx) DeleteBucket(ds uint16, bucket string) error {
 	}
 
 	b := &Bucket{
-		meta: &BucketMeta{
+		Meta: &BucketMeta{
 			Op: BucketDeleteOperation,
 		},
 		Id:   tx.db.bm.Gen.GenId(),

--- a/tx_bucket_test.go
+++ b/tx_bucket_test.go
@@ -30,6 +30,10 @@ var (
 func setupBucket(t *testing.T, db *DB) {
 	key := GetTestBytes(0)
 	val := GetTestBytes(1)
+	txCreateBucket(t, db, DataStructureBTree, stringBucketName, nil)
+	txCreateBucket(t, db, DataStructureSet, setBucketName, nil)
+	txCreateBucket(t, db, DataStructureSortedSet, zSetBucketName, nil)
+	txCreateBucket(t, db, DataStructureList, listBucketName, nil)
 
 	txSAdd(t, db, setBucketName, key, val, nil, nil)
 	txZAdd(t, db, zSetBucketName, key, val, 80, nil, nil)
@@ -83,6 +87,5 @@ func TestBucket_DeleteBucket(t *testing.T) {
 		txDeleteBucket(t, db, DataStructureList, listBucketName, nil)
 		txDeleteBucket(t, db, DataStructureBTree, stringBucketName, nil)
 
-		txDeleteBucket(t, db, DataStructureNone, "none_bucket", ErrDataStructureNotSupported)
 	})
 }

--- a/tx_error.go
+++ b/tx_error.go
@@ -47,7 +47,9 @@ var (
 	ErrTxnTooBig = errors.New("Txn is too big to fit into one request")
 
 	// ErrTxnExceedWriteLimit is returned when this tx's write is exceed max write record
-	ErrTxnExceedWriteLimit = errors.New("Txn is exceed max write record count")
+	ErrTxnExceedWriteLimit = errors.New("txn is exceed max write record count")
 
 	ErrBucketAlreadyExist = errors.New("bucket is already exist")
+
+	ErrorBucketNotExist = errors.New("bucket is not exist yet, please use NewBucket function to create this bucket first")
 )

--- a/tx_error.go
+++ b/tx_error.go
@@ -48,4 +48,6 @@ var (
 
 	// ErrTxnExceedWriteLimit is returned when this tx's write is exceed max write record
 	ErrTxnExceedWriteLimit = errors.New("Txn is exceed max write record count")
+
+	ErrBucketAlreadyExist = errors.New("bucket is already exist")
 )

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -154,7 +154,7 @@ func TestTx_RPop(t *testing.T) {
 		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, false)
 
-		txPop(t, db, "fake_bucket", GetTestBytes(0), nil, ErrListNotFound, false)
+		txPop(t, db, "fake_bucket", GetTestBytes(0), nil, ErrBucketNotExist, false)
 
 		for i := 0; i < 3; i++ {
 			txPop(t, db, bucket, GetTestBytes(0), GetTestBytes(2-i), nil, false)
@@ -441,7 +441,7 @@ func TestTx_ListEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		listIdx := db.Index.list.getWithDefault(bucket)
+		listIdx := db.Index.list.getWithDefault(1)
 		item, ok := listIdx.Items[string(key)].PopMin()
 		r := item.r
 		require.True(t, ok)
@@ -468,7 +468,7 @@ func TestTx_ListEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		listIdx := db.Index.list.getWithDefault(bucket)
+		listIdx := db.Index.list.getWithDefault(1)
 		item, ok := listIdx.Items[string(key)].PopMin()
 		r := item.r
 		require.True(t, ok)

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -39,6 +39,7 @@ func TestTx_RPush(t *testing.T) {
 	// 1. Insert values for some keys by using RPush
 	// 2. Validate values for these keys by using RPop
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 9, false)
 		pushDataByStartEnd(t, db, bucket, 1, 10, 19, false)
 		pushDataByStartEnd(t, db, bucket, 2, 20, 29, false)
@@ -61,6 +62,8 @@ func TestTx_LPush(t *testing.T) {
 	// 1. Insert values for some keys by using LPush
 	// 2. Validate values for these keys by using LPop
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		pushDataByStartEnd(t, db, bucket, 0, 0, 9, true)
 		pushDataByStartEnd(t, db, bucket, 1, 10, 19, true)
 		pushDataByStartEnd(t, db, bucket, 2, 20, 29, true)
@@ -82,6 +85,8 @@ func TestTx_LPush(t *testing.T) {
 func TestTx_LPushRaw(t *testing.T) {
 	bucket := "bucket"
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		seq := uint64(100000)
 		for i := 0; i <= 100; i++ {
 			key := encodeListKey([]byte("0"), seq)
@@ -99,6 +104,7 @@ func TestTx_LPushRaw(t *testing.T) {
 func TestTx_RPushRaw(t *testing.T) {
 	bucket := "bucket"
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		seq := uint64(100000)
 		for i := 0; i <= 100; i++ {
 			key := encodeListKey([]byte("0"), seq)
@@ -120,11 +126,13 @@ func TestTx_LPop(t *testing.T) {
 
 	// Calling LPop on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txPop(t, db, bucket, GetTestBytes(0), nil, ErrListNotFound, true)
 	})
 
 	// Insert some values for a key and validate them by using LPop
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, true)
 		for i := 0; i < 3; i++ {
 			txPop(t, db, bucket, GetTestBytes(0), GetTestBytes(2-i), nil, true)
@@ -137,11 +145,13 @@ func TestTx_RPop(t *testing.T) {
 
 	// Calling RPop on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txPop(t, db, bucket, GetTestBytes(0), nil, ErrListNotFound, false)
 	})
 
 	// Calling RPop on a list with added data
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, false)
 
 		txPop(t, db, "fake_bucket", GetTestBytes(0), nil, ErrListNotFound, false)
@@ -159,11 +169,15 @@ func TestTx_LRange(t *testing.T) {
 
 	// Calling LRange on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 0, nil, ErrListNotFound)
 	})
 
 	// Calling LRange on a list with added data
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, true)
 
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 3, [][]byte{
@@ -183,11 +197,14 @@ func TestTx_LRem(t *testing.T) {
 
 	// Calling LRem on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txLRem(t, db, bucket, GetTestBytes(0), 1, GetTestBytes(0), ErrListNotFound)
 	})
 
 	// A basic calling for LRem
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		pushDataByStartEnd(t, db, bucket, 0, 0, 3, true)
 
 		txLRem(t, db, bucket, GetTestBytes(0), 1, GetTestBytes(0), nil)
@@ -200,6 +217,8 @@ func TestTx_LRem(t *testing.T) {
 
 	// Calling LRem with count > 0
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		count := 3
 
 		pushDataByValues(t, db, bucket, 1, true, 0, 1, 0, 1, 0, 1, 0, 1)
@@ -216,6 +235,7 @@ func TestTx_LRem(t *testing.T) {
 
 	// Calling LRem with count == 0
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		count := 0
 
 		pushDataByValues(t, db, bucket, 1, true, 0, 1, 0, 1, 0, 1, 0, 1)
@@ -232,6 +252,8 @@ func TestTx_LRem(t *testing.T) {
 
 	// Calling LRem with count < 0
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		count := -3
 
 		pushDataByValues(t, db, bucket, 1, true, 0, 1, 0, 1, 0, 1, 0, 1)
@@ -252,11 +274,13 @@ func TestTx_LTrim(t *testing.T) {
 
 	// Calling LTrim on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txLTrim(t, db, bucket, GetTestBytes(0), 0, 1, ErrListNotFound)
 	})
 
 	// Calling LTrim on a list with added data and use LRange to validate it
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, true)
 		txLTrim(t, db, bucket, GetTestBytes(0), 0, 1, nil)
 
@@ -267,6 +291,8 @@ func TestTx_LTrim(t *testing.T) {
 
 	// Calling LTrim with incorrect start and end
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
+
 		for i := 0; i < 3; i++ {
 			txPush(t, db, bucket, GetTestBytes(2), GetTestBytes(i), true, nil, nil)
 		}
@@ -279,11 +305,13 @@ func TestTx_LSize(t *testing.T) {
 
 	// Calling LSize on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txLSize(t, db, bucket, GetTestBytes(0), 0, ErrListNotFound)
 	})
 
 	// Calling LSize after adding some values
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, false)
 		txLSize(t, db, bucket, GetTestBytes(0), 3, nil)
 	})
@@ -294,17 +322,20 @@ func TestTx_LRemByIndex(t *testing.T) {
 
 	// Calling LRemByIndex on a non-existent list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txLRemByIndex(t, db, bucket, GetTestBytes(0), ErrListNotFound)
 	})
 
 	// Calling LRemByIndex with len(indexes) == 0
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByValues(t, db, bucket, 0, true, 0)
 		txLRemByIndex(t, db, bucket, GetTestBytes(0), nil)
 	})
 
 	// Calling LRemByIndex with a expired bucket name
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByValues(t, db, bucket, 0, true, 0)
 		txExpireList(t, db, bucket, GetTestBytes(0), 1, nil)
 		time.Sleep(3 * time.Second)
@@ -313,6 +344,7 @@ func TestTx_LRemByIndex(t *testing.T) {
 
 	// Calling LRemByIndex on a list with added data and use LRange to validate it
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, false)
 		txLRemByIndex(t, db, bucket, GetTestBytes(0), nil, 1, 0, 8, -8, 88, -88)
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 1, [][]byte{
@@ -326,6 +358,7 @@ func TestTx_ExpireList(t *testing.T) {
 
 	// Verify that the list with expiration time expires normally
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 3, false)
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 4, [][]byte{
 			GetTestBytes(0), GetTestBytes(1), GetTestBytes(2), GetTestBytes(3),
@@ -338,6 +371,7 @@ func TestTx_ExpireList(t *testing.T) {
 
 	// Verify that the list with persistent time
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 3, false)
 		txExpireList(t, db, bucket, GetTestBytes(0), Persistent, nil)
 		time.Sleep(time.Second)
@@ -352,6 +386,7 @@ func TestTx_LKeys(t *testing.T) {
 
 	// Calling LKeys after adding some keys
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByValues(t, db, bucket, 10, false, 0)
 		pushDataByValues(t, db, bucket, 11, false, 1)
 		pushDataByValues(t, db, bucket, 12, false, 2)
@@ -376,6 +411,7 @@ func TestTx_GetListTTL(t *testing.T) {
 
 	// Verify TTL of list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 3, false)
 
 		txGetListTTL(t, db, bucket, GetTestBytes(0), uint32(0), nil)
@@ -396,6 +432,7 @@ func TestTx_ListEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 
 	// HintKeyValAndRAMIdxMode
 	runNutsDBTest(t, &opts, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		err := db.Update(func(tx *Tx) error {
 			err := tx.LPush(bucket, key, []byte("d"), []byte("c"), []byte("b"), []byte("a"))
 			require.NoError(t, err)
@@ -422,6 +459,7 @@ func TestTx_ListEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 
 	// HintKeyAndRAMIdxMode
 	runNutsDBTest(t, opts, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		err := db.Update(func(tx *Tx) error {
 			err := tx.LPush(bucket, key, []byte("d"), []byte("c"), []byte("b"), []byte("a"))
 			require.NoError(t, err)

--- a/tx_set_test.go
+++ b/tx_set_test.go
@@ -103,7 +103,7 @@ func TestTx_SMembers(t *testing.T) {
 		txSIsMember(t, db, bucket, key, val1, true)
 		txSIsMember(t, db, bucket, key, val1, true)
 
-		txSMembers(t, db, fakeBucket, key, 0, ErrBucketNotFound)
+		txSMembers(t, db, fakeBucket, key, 0, ErrBucketNotExist)
 	})
 }
 
@@ -123,7 +123,7 @@ func TestTx_SCard(t *testing.T) {
 
 		txSCard(t, db, bucket, key, 3, nil)
 
-		txSCard(t, db, fakeBucket, key, 0, ErrBucketNotFound)
+		txSCard(t, db, fakeBucket, key, 0, ErrBucketNotExist)
 	})
 }
 
@@ -151,7 +151,7 @@ func TestTx_SDiffByOneBucket(t *testing.T) {
 
 		diff := [][]byte{val1, val2}
 		txSDiffByOneBucket(t, db, bucket, key1, key2, diff, nil)
-		txSDiffByOneBucket(t, db, fakeBucket, key2, key1, nil, ErrBucketNotFound)
+		txSDiffByOneBucket(t, db, fakeBucket, key2, key1, nil, ErrBucketNotExist)
 
 		txSAdd(t, db, bucket, key3, val1, nil, nil)
 		txSAdd(t, db, bucket, key3, val2, nil, nil)
@@ -192,8 +192,8 @@ func TestTx_SDiffByTwoBuckets(t *testing.T) {
 		diff := [][]byte{val1, val2}
 		txSDiffByTwoBucket(t, db, bucket1, key1, bucket2, key2, diff, nil)
 
-		txSDiffByTwoBucket(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, nil, ErrBucketNotFound)
-		txSDiffByTwoBucket(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, nil, ErrBucketNotFound)
+		txSDiffByTwoBucket(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, nil, ErrBucketNotExist)
+		txSDiffByTwoBucket(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, nil, ErrBucketNotExist)
 
 		txSAdd(t, db, bucket3, key3, val1, nil, nil)
 		txSAdd(t, db, bucket3, key3, val2, nil, nil)
@@ -222,7 +222,7 @@ func TestTx_SPop(t *testing.T) {
 		txSPop(t, db, bucket, key, nil)
 		txSCard(t, db, bucket, key, 2, nil)
 
-		txSPop(t, db, fakeBucket, key, ErrBucketNotFound)
+		txSPop(t, db, fakeBucket, key, ErrBucketNotExist)
 	})
 
 }
@@ -247,7 +247,7 @@ func TestTx_SMoveByOneBucket(t *testing.T) {
 		txSIsMember(t, db, bucket, key1, val2, false)
 		txSIsMember(t, db, bucket, key2, val2, true)
 
-		txSMoveByOneBucket(t, db, fakeBucket, key1, key2, val2, false, ErrBucket)
+		txSMoveByOneBucket(t, db, fakeBucket, key1, key2, val2, false, ErrBucketNotExist)
 	})
 }
 
@@ -277,9 +277,9 @@ func TestTx_SMoveByTwoBuckets(t *testing.T) {
 
 		txSMoveByTwoBuckets(t, db, bucket1, fakeKey1, bucket2, key2, val2, false, ErrNotFoundKey)
 		txSMoveByTwoBuckets(t, db, bucket1, key1, bucket2, fakeKey2, val2, false, ErrNotFoundKey)
-		txSMoveByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, val2, false, ErrBucketNotFound)
-		txSMoveByTwoBuckets(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, val2, false, ErrBucketNotFound)
-		txSMoveByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, fmt.Sprintf(fakeBucket, 2), key2, val2, false, ErrBucketNotFound)
+		txSMoveByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, val2, false, ErrBucketNotExist)
+		txSMoveByTwoBuckets(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, val2, false, ErrBucketNotExist)
+		txSMoveByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, fmt.Sprintf(fakeBucket, 2), key2, val2, false, ErrBucketNotExist)
 	})
 }
 
@@ -308,7 +308,7 @@ func TestTx_SUnionByOneBucket(t *testing.T) {
 			txSIsMember(t, db, bucket, key3, item, true)
 		}
 
-		txSUnionByOneBucket(t, db, fakeBucket, key1, key2, nil, ErrBucket)
+		txSUnionByOneBucket(t, db, fakeBucket, key1, key2, nil, ErrBucketNotExist)
 	})
 }
 
@@ -334,8 +334,8 @@ func TestTx_SUnionByTwoBuckets(t *testing.T) {
 		all := [][]byte{val1, val2, val3}
 		txSUnionByTwoBuckets(t, db, bucket1, key1, bucket2, key2, all, nil)
 
-		txSUnionByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, nil, ErrBucketNotFound)
-		txSUnionByTwoBuckets(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, nil, ErrBucketNotFound)
+		txSUnionByTwoBuckets(t, db, fmt.Sprintf(fakeBucket, 1), key1, bucket2, key2, nil, ErrBucketNotExist)
+		txSUnionByTwoBuckets(t, db, bucket1, key1, fmt.Sprintf(fakeBucket, 2), key2, nil, ErrBucketNotExist)
 		txSUnionByTwoBuckets(t, db, bucket1, fakeKey1, bucket2, key2, nil, ErrNotFoundKey)
 		txSUnionByTwoBuckets(t, db, bucket1, key1, bucket2, fakeKey2, nil, ErrNotFoundKey)
 	})

--- a/tx_set_test.go
+++ b/tx_set_test.go
@@ -26,6 +26,7 @@ func TestTx_SAdd(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, []byte(""), []byte("val1"), ErrKeyEmpty, nil)
 
 		key := GetTestBytes(0)
@@ -46,6 +47,7 @@ func TestTx_SRem(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		key := []byte("key1")
 		val1 := []byte("one")
 		val2 := []byte("two")
@@ -71,6 +73,7 @@ func TestTx_SRem2(t *testing.T) {
 	val2 := GetTestBytes(1)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val1, nil, nil)
 		txSAdd(t, db, bucket, key, val2, nil, nil)
 
@@ -91,6 +94,7 @@ func TestTx_SMembers(t *testing.T) {
 	val2 := GetTestBytes(1)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val1, nil, nil)
 		txSAdd(t, db, bucket, key, val2, nil, nil)
 
@@ -112,6 +116,7 @@ func TestTx_SCard(t *testing.T) {
 	val3 := GetTestBytes(3)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val1, nil, nil)
 		txSAdd(t, db, bucket, key, val2, nil, nil)
 		txSAdd(t, db, bucket, key, val3, nil, nil)
@@ -135,6 +140,7 @@ func TestTx_SDiffByOneBucket(t *testing.T) {
 	val5 := GetTestBytes(5)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key1, val1, nil, nil)
 		txSAdd(t, db, bucket, key1, val2, nil, nil)
 		txSAdd(t, db, bucket, key1, val3, nil, nil)
@@ -171,6 +177,10 @@ func TestTx_SDiffByTwoBuckets(t *testing.T) {
 	val5 := GetTestBytes(5)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket1, nil)
+		txCreateBucket(t, db, DataStructureSet, bucket2, nil)
+		txCreateBucket(t, db, DataStructureSet, bucket3, nil)
+
 		txSAdd(t, db, bucket1, key1, val1, nil, nil)
 		txSAdd(t, db, bucket1, key1, val2, nil, nil)
 		txSAdd(t, db, bucket1, key1, val3, nil, nil)
@@ -203,6 +213,7 @@ func TestTx_SPop(t *testing.T) {
 	val3 := GetTestBytes(3)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val1, nil, nil)
 		txSAdd(t, db, bucket, key, val2, nil, nil)
 		txSAdd(t, db, bucket, key, val3, nil, nil)
@@ -226,6 +237,7 @@ func TestTx_SMoveByOneBucket(t *testing.T) {
 	val3 := GetTestBytes(3)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key1, val1, nil, nil)
 		txSAdd(t, db, bucket, key1, val2, nil, nil)
 
@@ -252,6 +264,8 @@ func TestTx_SMoveByTwoBuckets(t *testing.T) {
 	val3 := GetTestBytes(3)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket1, nil)
+		txCreateBucket(t, db, DataStructureSet, bucket2, nil)
 		txSAdd(t, db, bucket1, key1, val1, nil, nil)
 		txSAdd(t, db, bucket1, key1, val2, nil, nil)
 
@@ -280,6 +294,7 @@ func TestTx_SUnionByOneBucket(t *testing.T) {
 	val2 := GetTestBytes(2)
 	val3 := GetTestBytes(3)
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key1, val1, nil, nil)
 		txSAdd(t, db, bucket, key1, val2, nil, nil)
 		txSAdd(t, db, bucket, key2, val3, nil, nil)
@@ -310,6 +325,8 @@ func TestTx_SUnionByTwoBuckets(t *testing.T) {
 	val3 := GetTestBytes(3)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket1, nil)
+		txCreateBucket(t, db, DataStructureSet, bucket2, nil)
 		txSAdd(t, db, bucket1, key1, val1, nil, nil)
 		txSAdd(t, db, bucket1, key1, val2, nil, nil)
 		txSAdd(t, db, bucket2, key2, val3, nil, nil)
@@ -330,6 +347,7 @@ func TestTx_SHasKey(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, GetTestBytes(1), nil, nil)
 
 		txSHasKey(t, db, bucket, key, true)
@@ -346,6 +364,7 @@ func TestTx_SIsMember(t *testing.T) {
 	fakeVal := GetTestBytes(1)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val, nil, nil)
 
 		txSIsMember(t, db, bucket, key, val, true)
@@ -365,6 +384,7 @@ func TestTx_SAreMembers(t *testing.T) {
 	fakeVal := GetTestBytes(2)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		txSAdd(t, db, bucket, key, val1, nil, nil)
 		txSAdd(t, db, bucket, key, val2, nil, nil)
 
@@ -384,6 +404,7 @@ func TestTx_SKeys(t *testing.T) {
 	val := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSet, bucket, nil)
 		num := 3
 		for i := 0; i < num; i++ {
 			txSAdd(t, db, bucket, []byte(fmt.Sprintf(key, i)), val, nil, nil)

--- a/tx_test.go
+++ b/tx_test.go
@@ -24,15 +24,12 @@ import (
 
 // todo to check is there any deadlock here?
 func TestTx_Rollback(t *testing.T) {
-	t.Skip()
 
 	withDefaultDB(t, func(t *testing.T, db *DB) {
-
-		tx, err := db.Begin(true)
-		assert.NoError(t, err)
-
 		bucket := "bucket_rollback_test"
 		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+		tx, err := db.Begin(true)
+		assert.NoError(t, err)
 
 		for i := 0; i < 10; i++ {
 			key := []byte("key_" + fmt.Sprintf("%03d", i))

--- a/tx_test.go
+++ b/tx_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// todo to check is there any deadlock here?
 func TestTx_Rollback(t *testing.T) {
+	t.Skip()
 
 	withDefaultDB(t, func(t *testing.T, db *DB) {
 
@@ -30,6 +32,7 @@ func TestTx_Rollback(t *testing.T) {
 		assert.NoError(t, err)
 
 		bucket := "bucket_rollback_test"
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
 		for i := 0; i < 10; i++ {
 			key := []byte("key_" + fmt.Sprintf("%03d", i))
@@ -148,6 +151,7 @@ func TestTx_CommittedStatus(t *testing.T) {
 		bucket := "bucket_committed_status"
 
 		{ // setup data
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 			tx, err := db.Begin(true)
 			assert.NoError(t, err)
 
@@ -187,6 +191,8 @@ func TestTx_PutWithTimestamp(t *testing.T) {
 		timestamps := []uint64{1547707905, 1547707910, uint64(time.Now().Unix())}
 
 		{ // put with timestamp
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
 			tx, err := db.Begin(true)
 			assert.NoError(t, err)
 			for i, timestamp := range timestamps {

--- a/tx_zset.go
+++ b/tx_zset.go
@@ -55,7 +55,13 @@ func (tx *Tx) ZMembers(bucket string, key []byte) (map[*SortedSetMember]struct{}
 		return nil, err
 	}
 
-	members, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZMembers(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	members, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZMembers(string(key))
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +87,13 @@ func (tx *Tx) ZCard(bucket string, key []byte) (int, error) {
 		return 0, err
 	}
 
-	card, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZCard(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return 0, err
+	}
+	bucketId := b.Id
+
+	card, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZCard(string(key))
 	if err != nil {
 		return 0, err
 	}
@@ -98,7 +110,13 @@ func (tx *Tx) ZCount(bucket string, key []byte, start, end float64, opts *GetByS
 		return 0, err
 	}
 
-	count, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZCount(string(key), SCORE(start), SCORE(end), opts)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return 0, err
+	}
+	bucketId := b.Id
+
+	count, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZCount(string(key), SCORE(start), SCORE(end), opts)
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +130,13 @@ func (tx *Tx) ZPopMax(bucket string, key []byte) (*SortedSetMember, error) {
 		return nil, err
 	}
 
-	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZPeekMax(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZPeekMax(string(key))
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +155,12 @@ func (tx *Tx) ZPopMin(bucket string, key []byte) (*SortedSetMember, error) {
 		return nil, err
 	}
 
-	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZPeekMin(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZPeekMin(string(key))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +179,13 @@ func (tx *Tx) ZPeekMax(bucket string, key []byte) (*SortedSetMember, error) {
 		return nil, err
 	}
 
-	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZPeekMax(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZPeekMax(string(key))
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +204,13 @@ func (tx *Tx) ZPeekMin(bucket string, key []byte) (*SortedSetMember, error) {
 		return nil, err
 	}
 
-	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZPeekMin(string(key))
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	record, score, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZPeekMin(string(key))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +230,12 @@ func (tx *Tx) ZRangeByScore(bucket string, key []byte, start, end float64, opts 
 		return nil, err
 	}
 
-	records, scores, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZRangeByScore(string(key), SCORE(start), SCORE(end), opts)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+	records, scores, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZRangeByScore(string(key), SCORE(start), SCORE(end), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +259,13 @@ func (tx *Tx) ZRangeByRank(bucket string, key []byte, start, end int) ([]*Sorted
 		return nil, err
 	}
 
-	records, scores, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZRangeByRank(string(key), start, end)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	records, scores, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZRangeByRank(string(key), start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +288,12 @@ func (tx *Tx) ZRem(bucket string, key []byte, value []byte) error {
 		return err
 	}
 
-	exist, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZExist(string(key), value)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return err
+	}
+	bucketId := b.Id
+	exist, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZExist(string(key), value)
 	if err != nil {
 		return err
 	}
@@ -266,7 +323,12 @@ func (tx *Tx) ZRank(bucket string, key, value []byte) (int, error) {
 		return 0, err
 	}
 
-	return tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZRank(string(key), value)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return 0, err
+	}
+	bucketId := b.Id
+	return tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZRank(string(key), value)
 }
 
 // ZRevRank Returns the rank of member in the sorted set specified by key in a bucket, with the scores ordered from high to low.
@@ -275,7 +337,12 @@ func (tx *Tx) ZRevRank(bucket string, key, value []byte) (int, error) {
 		return 0, err
 	}
 
-	return tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZRevRank(string(key), value)
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return 0, err
+	}
+	bucketId := b.Id
+	return tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZRevRank(string(key), value)
 }
 
 // ZScore Returns the score of members in a sorted set specified by key in a bucket.
@@ -284,7 +351,12 @@ func (tx *Tx) ZScore(bucket string, key, value []byte) (float64, error) {
 		return 0, err
 	}
 
-	if score, err := tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).ZScore(string(key), value); err != nil {
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return 0.0, err
+	}
+	bucketId := b.Id
+	if score, err := tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).ZScore(string(key), value); err != nil {
 		return 0, err
 	} else {
 		return score, nil
@@ -296,7 +368,13 @@ func (tx *Tx) ZKeys(bucket, pattern string, f func(key string) bool) error {
 	if err := tx.ZCheck(bucket); err != nil {
 		return err
 	}
-	for key := range tx.db.Index.sortedSet.getWithDefault(bucket, tx.db).M {
+
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return err
+	}
+	bucketId := b.Id
+	for key := range tx.db.Index.sortedSet.getWithDefault(bucketId, tx.db).M {
 		if end, err := MatchForRange(pattern, key, f); end || err != nil {
 			return err
 		}
@@ -308,7 +386,13 @@ func (tx *Tx) ZCheck(bucket string) error {
 	if err := tx.checkTxIsClosed(); err != nil {
 		return err
 	}
-	if _, ok := tx.db.Index.sortedSet.exist(bucket); !ok {
+
+	b, err := tx.db.bm.GetBucket(Ds(DataStructureSortedSet), BucketName(bucket))
+	if err != nil {
+		return err
+	}
+	bucketId := b.Id
+	if _, ok := tx.db.Index.sortedSet.exist(bucketId); !ok {
 		return ErrBucket
 	}
 	return nil

--- a/tx_zset_test.go
+++ b/tx_zset_test.go
@@ -25,7 +25,7 @@ var tx *Tx
 func TestTx_ZCheck(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		err := db.View(func(tx *Tx) error {
-			require.Equal(t, ErrBucket, tx.ZCheck("fake bucket"))
+			require.Equal(t, ErrBucketNotExist, tx.ZCheck("fake bucket"))
 			return nil
 		})
 		require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestTx_ZSetEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		zset := db.Index.sortedSet.getWithDefault(bucket, db).M[string(key)]
+		zset := db.Index.sortedSet.getWithDefault(1, db).M[string(key)]
 		hash, _ := getFnv32(value)
 		node := zset.dict[hash]
 
@@ -382,7 +382,7 @@ func TestTx_ZSetEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		zset := db.Index.sortedSet.getWithDefault(bucket, db).M[string(key)]
+		zset := db.Index.sortedSet.getWithDefault(1, db).M[string(key)]
 		hash, _ := getFnv32(value)
 		node := zset.dict[hash]
 

--- a/tx_zset_test.go
+++ b/tx_zset_test.go
@@ -37,6 +37,7 @@ func TestTx_ZAdd(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 		for i := 0; i < 10; i++ {
 			txZAdd(t, db, bucket, GetTestBytes(0), GetTestBytes(i), float64(i), nil, nil)
 		}
@@ -49,6 +50,7 @@ func TestTx_ZScore(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 		for i := 0; i < 10; i++ {
 			txZAdd(t, db, bucket, GetTestBytes(0), GetTestBytes(i), float64(i), nil, nil)
 		}
@@ -70,6 +72,8 @@ func TestTx_ZRem(t *testing.T) {
 	bucket := "bucket"
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+
 		for i := 0; i < 10; i++ {
 			txZAdd(t, db, bucket, GetTestBytes(0), GetTestBytes(i), float64(i), nil, nil)
 		}
@@ -96,6 +100,8 @@ func TestTx_ZMembers(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+
 		for i := 0; i < 10; i++ {
 			txZAdd(t, db, bucket, key, GetTestBytes(i), float64(i), nil, nil)
 		}
@@ -122,6 +128,8 @@ func TestTx_ZCount(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+
 		for i := 0; i < 30; i++ {
 			txZAdd(t, db, bucket, key, GetRandomBytes(24), float64(i), nil, nil)
 		}
@@ -143,6 +151,7 @@ func TestTx_ZPop(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 
 		txZPop(t, db, bucket, key, true, nil, 0, ErrBucket)
 		txZPop(t, db, bucket, key, false, nil, 0, ErrBucket)
@@ -170,6 +179,7 @@ func TestTx_ZRangeByRank(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 
 		err := db.View(func(tx *Tx) error {
 			_, err := tx.ZRangeByRank(bucket, key, 1, 10)
@@ -227,6 +237,7 @@ func TestTx_ZRemRangeByRank(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 
 		err := db.Update(func(tx *Tx) error {
 			err := tx.ZRemRangeByRank(bucket, key, 1, 10)
@@ -299,6 +310,8 @@ func TestTx_ZRank(t *testing.T) {
 	key := GetTestBytes(0)
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+
 		txZRank(t, db, bucket, key, GetTestBytes(0), true, 0, ErrBucket)
 		txZRank(t, db, bucket, key, GetTestBytes(0), false, 0, ErrBucket)
 
@@ -331,6 +344,8 @@ func TestTx_ZSetEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 
 	// HintKeyValAndRAMIdxMode
 	runNutsDBTest(t, &opts, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+
 		err := db.Update(func(tx *Tx) error {
 			err := tx.ZAdd(bucket, key, float64(0), value)
 			require.NoError(t, err)
@@ -358,6 +373,7 @@ func TestTx_ZSetEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 
 	// HintKeyValAndRAMIdxMode
 	runNutsDBTest(t, &opts, func(t *testing.T, db *DB) {
+		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 		err := db.Update(func(tx *Tx) error {
 			err := tx.ZAdd(bucket, key, float64(0), value)
 			require.NoError(t, err)


### PR DESCRIPTION
The concept Bucket is like the Table in MySQL. User can separate their data into different buckets. Currently, we only support insert and delete operations for buckets. We would like to extend the usage and functionalities for it. That is what this feature going to do. Currently, this PR only has a basic implementation of bucket management and bucket storage. And it still has so much work to do. Here is a to-do list. And I will implement them one by one.

- [ ] Add more test cases for this feature
- [x] Filter the entry if the bucket was been deleted when recovering the database
- [x] Delete the bucket-related stuff in the entry entity.
- [ ] Add update bucket API
- [ ] make the creation and deletion of the bucket visible for a transaction. 

The change for the Index module:
- [x]  Use the bucket id for the key of the mapper.
