### PR TITLE
Only overwrite the managed error when a rollback error occurs

### DIFF
--- a/db.go
+++ b/db.go
@@ -890,8 +890,7 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 			db.opt.ErrorHandler.HandleError(err)
 		}
 
-		errRollback := tx.Rollback()
-		if errRollback != nil {
+		if errRollback := tx.Rollback(); errRollback != nil {
 			err = fmt.Errorf("%v. Rollback err: %v", err, errRollback)
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -891,7 +891,9 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 		}
 
 		errRollback := tx.Rollback()
-		err = fmt.Errorf("%v. Rollback err: %v", err, errRollback)
+		if errRollback != nil {
+			err = fmt.Errorf("%v. Rollback err: %v", err, errRollback)
+		}
 	}
 
 	return err


### PR DESCRIPTION
### Fixes https://github.com/nutsdb/nutsdb/issues/492

- Changes `managed` so that the error is only overwritten when a rollback error occurs. Otherwise it leaves it as is.
- This means that you can continue to check the errors against the static error variables e.g. `nutsdb.ErrBucketEmpty`

