### PR TITLE
feat: use variable length storage to implement storage protocols to save disk space

### DIFF
--- a/datafile.go
+++ b/datafile.go
@@ -19,9 +19,6 @@ import (
 )
 
 var (
-	// ErrCrcZero is returned when crc is 0
-	ErrCrcZero = errors.New("error crc is 0")
-
 	// ErrCrc is returned when crc is error
 	ErrCrc = errors.New("crc error")
 
@@ -30,13 +27,6 @@ var (
 
 	ErrEntryZero = errors.New("entry is zero ")
 )
-
-// DataEntryHeaderSize returns the entry header size
-var DataEntryHeaderSize int64
-
-func init() {
-	DataEntryHeaderSize = GetDiskSizeFromSingleObject(MetaData{})
-}
 
 const (
 	// DataSuffix returns the data suffix
@@ -61,61 +51,28 @@ func NewDataFile(path string, rwManager RWManager) *DataFile {
 	return dataFile
 }
 
-// ReadAt returns entry at the given off(offset).
-func (df *DataFile) ReadAt(off int) (e *Entry, err error) {
-	buf := make([]byte, DataEntryHeaderSize)
-
-	if _, err := df.rwManager.ReadAt(buf, int64(off)); err != nil {
-		return nil, err
-	}
-
-	e = NewEntry()
-	err = e.ParseMeta(buf)
-	if err != nil {
-		return nil, err
-	}
-
-	if e.IsZero() {
-		return nil, nil
-	}
-
-	meta := e.Meta
-	off += int(DataEntryHeaderSize)
-	dataSize := meta.PayloadSize()
-
-	dataBuf := make([]byte, dataSize)
-	_, err = df.rwManager.ReadAt(dataBuf, int64(off))
-	if err != nil {
-		return nil, err
-	}
-
-	err = e.ParsePayload(dataBuf)
-	if err != nil {
-		return nil, err
-	}
-
-	crc := e.GetCrc(buf)
-	if crc != e.Meta.Crc {
-		return nil, ErrCrc
-	}
-
-	return
-}
-
-// ReadRecord returns entry at the given off(offset).
+// ReadEntry returns entry at the given off(offset).
 // payloadSize = bucketSize + keySize + valueSize
-func (df *DataFile) ReadRecord(off int, payloadSize int64) (e *Entry, err error) {
-	buf := make([]byte, DataEntryHeaderSize+payloadSize)
+func (df *DataFile) ReadEntry(off int, payloadSize int64) (e *Entry, err error) {
+	size := MaxEntryHeaderSize + payloadSize
+	// Since MaxEntryHeaderSize + payloadSize may be larger than the actual entry size, it needs to be calculated
+	if int64(off)+size > df.rwManager.Size() {
+		size = df.rwManager.Size() - int64(off)
+	}
+	buf := make([]byte, size)
 
 	if _, err := df.rwManager.ReadAt(buf, int64(off)); err != nil {
 		return nil, err
 	}
 
 	e = new(Entry)
-	err = e.ParseMeta(buf)
+	headerSize, err := e.ParseMeta(buf)
 	if err != nil {
 		return nil, err
 	}
+
+	// Remove the content after the Header
+	buf = buf[:headerSize+int(payloadSize)]
 
 	if e.IsZero() {
 		return nil, ErrEntryZero
@@ -125,12 +82,12 @@ func (df *DataFile) ReadRecord(off int, payloadSize int64) (e *Entry, err error)
 		return nil, err
 	}
 
-	err = e.ParsePayload(buf[DataEntryHeaderSize:])
+	err = e.ParsePayload(buf[headerSize:])
 	if err != nil {
 		return nil, err
 	}
 
-	crc := e.GetCrc(buf[:DataEntryHeaderSize])
+	crc := e.GetCrc(buf[:headerSize])
 	if crc != e.Meta.Crc {
 		return nil, ErrCrc
 	}

--- a/datafile.go
+++ b/datafile.go
@@ -72,7 +72,7 @@ func (df *DataFile) ReadEntry(off int, payloadSize int64) (e *Entry, err error) 
 	}
 
 	// Remove the content after the Header
-	buf = buf[:headerSize+int(payloadSize)]
+	buf = buf[:int(headerSize+payloadSize)]
 
 	if e.IsZero() {
 		return nil, ErrEntryZero

--- a/datafile_test.go
+++ b/datafile_test.go
@@ -62,23 +62,8 @@ func TestDataFile1(t *testing.T) {
 		t.Error("err TestDataFile_All WriteAt")
 	}
 
-	e, err := df.ReadAt(n)
-	if e != nil || err != nil {
-		t.Error("err TestDataFile_All ReadAt")
-	}
-
-	e, err = df.ReadAt(0)
-	if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
-		t.Error("err TestDataFile_All ReadAt")
-	}
-
-	e, err = df.ReadAt(1)
-	if err == nil || e != nil {
-		t.Error("err TestDataFile_All ReadAt")
-	}
-
 	payloadSize := entry.Meta.PayloadSize()
-	e, err = df.ReadRecord(n, payloadSize)
+	e, err := df.ReadRecord(n, payloadSize)
 	assert.Nil(t, e)
 	assert.Error(t, err, ErrEntryZero)
 
@@ -106,13 +91,8 @@ func TestDataFile2(t *testing.T) {
 		t.Error("err TestDataFile_All WriteAt")
 	}
 
-	e, err := df.ReadAt(0)
-	if err == nil || e != nil {
-		t.Error("err TestDataFile_All ReadAt")
-	}
-
 	payloadSize := entry.Meta.PayloadSize()
-	e, err = df.ReadRecord(0, payloadSize)
+	e, err := df.ReadRecord(0, payloadSize)
 	if err == nil || e != nil {
 		t.Error("err TestDataFile_All ReadAt")
 	}
@@ -127,11 +107,6 @@ func TestDataFile2(t *testing.T) {
 	_, err = df2.WriteAt(content, 0)
 	assert.Nil(t, err)
 
-	e, err = df2.ReadAt(0)
-	if err == nil || e != nil {
-		t.Error("err TestDataFile_All ReadAt")
-	}
-
 	e, err = df2.ReadRecord(0, payloadSize)
 	if err == nil || e != nil {
 		t.Error("err TestDataFile_All ReadAt")
@@ -143,32 +118,6 @@ func TestDataFile2(t *testing.T) {
 	assert.Nil(t, err)
 	err = fm.close()
 	assert.Nil(t, err)
-}
-
-func TestDataFile_ReadAt(t *testing.T) {
-	fm := newFileManager(FileIO, 1024, 0.5)
-	filePath4 := "/tmp/foo4"
-	df, err := fm.getDataFile(filePath4, 1024)
-	defer func() {
-		err = df.Release()
-		assert.Nil(t, err)
-		err = fm.close()
-		assert.Nil(t, err)
-	}()
-	assert.Nil(t, err)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	e, err := df.ReadAt(0)
-	if err != nil && e != nil {
-		t.Error("err ReadAt")
-	}
-
-	e, err = df.ReadAt(1025)
-	if err == nil && e != nil {
-		t.Error("err ReadAt")
-	}
 }
 
 func TestDataFile_ReadRecord(t *testing.T) {
@@ -231,12 +180,8 @@ func TestDataFile_Crc_Err(t *testing.T) {
 	_, err = df.WriteAt(errContent, 0)
 	assert.Nil(t, err)
 
-	e, err := df.ReadAt(0)
-	if err == nil || e != nil {
-		t.Error("err TestDataFile_All ReadAt")
-	}
 	payloadSize := entry.Meta.PayloadSize()
-	e, err = df.ReadRecord(0, payloadSize)
+	e, err := df.ReadRecord(0, payloadSize)
 	if err == nil || e != nil {
 		t.Error("err TestDataFile_All ReadAt")
 	}
@@ -254,101 +199,4 @@ func TestFileManager1(t *testing.T) {
 		assert.Nil(t, err)
 		os.Remove(filePath)
 	}()
-}
-
-func Benchmark_Read(b *testing.B) {
-	b.Run("benchmarkReadRecord_FileIO", benchmarkReadRecord_FileIO)
-	b.Run("benchmarkReadAt_FileIO", benchmarkReadAt_FileIO)
-	b.Run("benchmarkReadRecord_MMap", benchmarkReadRecord_MMap)
-	b.Run("benchmarkReadAt_MMap", benchmarkReadAt_MMap)
-}
-
-func benchmarkReadAt_FileIO(b *testing.B) {
-	fm := newFileManager(FileIO, 1024, 0.5)
-	defer fm.close()
-	df, err := fm.getDataFile(filePath, 1024)
-	defer os.Remove(filePath)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	_, err = df.WriteAt(entry.Encode(), 0)
-	if err != nil {
-		b.Error("err benchmarkReadAt_FileIO WriteAt")
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		e, err := df.ReadAt(0)
-		if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
-			b.Error("err benchmarkReadAt_FileIO ReadAt")
-		}
-	}
-}
-
-func benchmarkReadRecord_FileIO(b *testing.B) {
-	fm := newFileManager(FileIO, 1024, 0.5)
-	defer fm.close()
-	df, err := fm.getDataFile(filePath, 1024)
-	defer os.Remove(filePath)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	_, err = df.WriteAt(entry.Encode(), 0)
-	if err != nil {
-		b.Error("err benchmarkReadRecord_FileIO WriteAt")
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		payloadSize := entry.Meta.PayloadSize()
-		e, err := df.ReadRecord(0, payloadSize)
-		if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
-			b.Error("err benchmarkReadRecord_FileIO ReadAt")
-		}
-	}
-}
-
-func benchmarkReadAt_MMap(b *testing.B) {
-	fm := newFileManager(MMap, 1024, 0.5)
-	defer fm.close()
-	df, err := fm.getDataFile(filePath, 1024)
-	defer os.Remove(filePath)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	_, err = df.WriteAt(entry.Encode(), 0)
-	if err != nil {
-		b.Error("err benchmarkReadAt_MMap WriteAt")
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		e, err := df.ReadAt(0)
-		if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
-			b.Error("err benchmarkReadAt_MMap ReadAt")
-		}
-	}
-}
-
-func benchmarkReadRecord_MMap(b *testing.B) {
-	fm := newFileManager(MMap, 1024, 0.5)
-	defer fm.close()
-	df, err := fm.getDataFile(filePath, 1024)
-	defer os.Remove(filePath)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	_, err = df.WriteAt(entry.Encode(), 0)
-	if err != nil {
-		b.Error("err benchmarkReadRecord_MMap WriteAt")
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		payloadSize := entry.Meta.PayloadSize()
-		e, err := df.ReadRecord(0, payloadSize)
-		if err != nil || string(e.Key) != "key_0001" || string(e.Value) != "val_0001" || e.Meta.Timestamp != 1547707905 {
-			b.Error("err benchmarkReadRecord_MMap ReadAt")
-		}
-	}
 }

--- a/db.go
+++ b/db.go
@@ -160,7 +160,7 @@ func open(opt Options) (*DB, error) {
 		KeyCount:         0,
 		closed:           false,
 		Index:            newIndex(),
-		fm:               newFileManager(opt.RWMode, opt.MaxFdNumsInCache, opt.CleanFdsCacheThreshold),
+		fm:               newFileManager(opt.RWMode, opt.MaxFdNumsInCache, opt.CleanFdsCacheThreshold, opt.SegmentSize),
 		mergeStartCh:     make(chan struct{}),
 		mergeEndCh:       make(chan error),
 		mergeWorkCloseCh: make(chan struct{}),
@@ -338,7 +338,7 @@ func (db *DB) getEntryByHint(h *Hint) (*Entry, error) {
 	}(df.rwManager)
 
 	payloadSize := h.Meta.PayloadSize()
-	item, err := df.ReadRecord(int(h.DataPos), payloadSize)
+	item, err := df.ReadEntry(int(h.DataPos), payloadSize)
 	if err != nil {
 		return nil, fmt.Errorf("read err. pos %d, key %s, err %s", h.DataPos, string(h.Key), err)
 	}
@@ -548,11 +548,11 @@ func (db *DB) parseDataFiles(dataFileIds []int) (err error) {
 
 	readEntriesFromFile := func() error {
 		for {
-			entry, err := f.readEntry()
+			entry, err := f.readEntry(off)
 			if err != nil {
 				// whatever which logic branch it will choose, we will release the fd.
 				_ = f.release()
-				if errors.Is(err, io.EOF) || errors.Is(err, ErrIndexOutOfBound) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, ErrEntryZero) {
+				if errors.Is(err, io.EOF) || errors.Is(err, ErrIndexOutOfBound) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, ErrEntryZero) || errors.Is(err, ErrHeaderSizeOutOfBounds) {
 					break
 				}
 				if off >= db.opt.SegmentSize {
@@ -896,11 +896,11 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic when executing tx, err is %+v", r)
-		}
-	}()
+	//defer func() {
+	//	if r := recover(); r != nil {
+	//		err = fmt.Errorf("panic when executing tx, err is %+v", r)
+	//	}
+	//}()
 
 	if err = fn(tx); err == nil {
 		err = tx.Commit()

--- a/db.go
+++ b/db.go
@@ -896,11 +896,11 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 	if err != nil {
 		return err
 	}
-	//defer func() {
-	//	if r := recover(); r != nil {
-	//		err = fmt.Errorf("panic when executing tx, err is %+v", r)
-	//	}
-	//}()
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic when executing tx, err is %+v", r)
+		}
+	}()
 
 	if err = fn(tx); err == nil {
 		err = tx.Commit()

--- a/db_test.go
+++ b/db_test.go
@@ -51,6 +51,7 @@ func removeDir(dir string) {
 func runNutsDBTest(t *testing.T, opts *Options, test func(t *testing.T, db *DB)) {
 	if opts == nil {
 		opts = &DefaultOptions
+		opts.EntryIdxMode = HintKeyAndRAMIdxMode
 	}
 	if opts.Dir == "" {
 		opts.Dir = NutsDBTestDirPath

--- a/entry.go
+++ b/entry.go
@@ -177,7 +177,7 @@ func (e *Entry) checkPayloadSize(size int64) error {
 }
 
 // ParseMeta parse Meta object to entry
-func (e *Entry) ParseMeta(buf []byte) (int, error) {
+func (e *Entry) ParseMeta(buf []byte) (int64, error) {
 	// If the length of the header is less than MinEntryHeaderSize,
 	// it means that the final remaining capacity of the file is not enough to write a record,
 	// and an error needs to be returned.
@@ -221,7 +221,7 @@ func (e *Entry) ParseMeta(buf []byte) (int, error) {
 		WithTxID(txId).
 		WithBucketId(bucketId)
 
-	return index, nil
+	return int64(index), nil
 }
 
 // isFilter to confirm if this entry is can be filtered

--- a/entry.go
+++ b/entry.go
@@ -24,7 +24,15 @@ import (
 	"github.com/xujiajun/utils/strconv2"
 )
 
-var payLoadSizeMismatchErr = errors.New("the payload size in Meta mismatch with the payload size needed")
+var (
+	ErrPayLoadSizeMismatch   = errors.New("the payload size in Meta mismatch with the payload size needed")
+	ErrHeaderSizeOutOfBounds = errors.New("the header size is out of bounds")
+)
+
+const (
+	MaxEntryHeaderSize = 4 + binary.MaxVarintLen32*3 + binary.MaxVarintLen64*3 + binary.MaxVarintLen16*3
+	MinEntryHeaderSize = 4 + 9
+)
 
 type (
 	// Entry represents the data item.
@@ -57,33 +65,53 @@ type (
 	}
 )
 
+func (meta *MetaData) Size() int64 {
+	// CRC
+	size := 4
+
+	size += UvarintSize(uint64(meta.KeySize))
+	size += UvarintSize(uint64(meta.ValueSize))
+	size += UvarintSize(meta.Timestamp)
+	size += UvarintSize(uint64(meta.TTL))
+	size += UvarintSize(uint64(meta.Flag))
+	size += UvarintSize(meta.TxID)
+	size += UvarintSize(uint64(meta.Status))
+	size += UvarintSize(uint64(meta.Ds))
+	size += UvarintSize(meta.BucketId)
+
+	return int64(size)
+}
+
 func (meta *MetaData) PayloadSize() int64 {
 	return int64(meta.KeySize) + int64(meta.ValueSize)
 }
 
 // Size returns the size of the entry.
 func (e *Entry) Size() int64 {
-	return DataEntryHeaderSize + int64(e.Meta.KeySize+e.Meta.ValueSize)
+	return e.Meta.Size() + int64(e.Meta.KeySize+e.Meta.ValueSize)
 }
 
 // Encode returns the slice after the entry be encoded.
 //
 //	the entry stored format:
-//	|----------------------------------------------------------------------------------------------------------------|
-//	|  crc  | timestamp | ksz | valueSize | flag  | TTL  |bucketSize| status | ds   | txId |  bucket |  key  | value |
-//	|----------------------------------------------------------------------------------------------------------------|
-//	| uint32| uint64  |uint32 |  uint32 | uint16  | uint32| uint32 | uint16 | uint16 |uint64 |[]byte|[]byte | []byte |
-//	|----------------------------------------------------------------------------------------------------------------|
+//	|----------------------------------------------------------------------------------------------------------|
+//	|  crc  | timestamp | ksz | valueSize | flag  | TTL  | status | ds   | txId |  bucketId |  key  | value    |
+//	|----------------------------------------------------------------------------------------------------------|
+//	| uint32| uint64  |uint32 |  uint32 | uint16  | uint32| uint16 | uint16 |uint64 | uint64 | []byte | []byte |
+//	|----------------------------------------------------------------------------------------------------------|
 func (e *Entry) Encode() []byte {
 	keySize := e.Meta.KeySize
 	valueSize := e.Meta.ValueSize
 
-	// set DataItemHeader buf
-	buf := make([]byte, e.Size())
-	buf = e.setEntryHeaderBuf(buf)
-	// set bucket\key\value
-	copy(buf[DataEntryHeaderSize:(DataEntryHeaderSize+int64(keySize))], e.Key)
-	copy(buf[(DataEntryHeaderSize+int64(keySize)):(DataEntryHeaderSize+int64(keySize+valueSize))], e.Value)
+	buf := make([]byte, MaxEntryHeaderSize+keySize+valueSize)
+
+	index := e.setEntryHeaderBuf(buf)
+	copy(buf[index:], e.Key)
+	index += int(keySize)
+	copy(buf[index:], e.Value)
+	index += int(valueSize)
+
+	buf = buf[:index]
 
 	c32 := crc32.ChecksumIEEE(buf[4:])
 	binary.LittleEndian.PutUint32(buf[0:4], c32)
@@ -92,19 +120,20 @@ func (e *Entry) Encode() []byte {
 }
 
 // setEntryHeaderBuf sets the entry header buff.
-func (e *Entry) setEntryHeaderBuf(buf []byte) []byte {
-	binary.LittleEndian.PutUint32(buf[0:4], e.Meta.Crc)
-	binary.LittleEndian.PutUint64(buf[4:12], e.Meta.Timestamp)
-	binary.LittleEndian.PutUint32(buf[12:16], e.Meta.KeySize)
-	binary.LittleEndian.PutUint32(buf[16:20], e.Meta.ValueSize)
-	binary.LittleEndian.PutUint16(buf[20:22], e.Meta.Flag)
-	binary.LittleEndian.PutUint32(buf[22:26], e.Meta.TTL)
-	binary.LittleEndian.PutUint16(buf[26:28], e.Meta.Status)
-	binary.LittleEndian.PutUint16(buf[28:30], e.Meta.Ds)
-	binary.LittleEndian.PutUint64(buf[30:38], e.Meta.TxID)
-	binary.LittleEndian.PutUint64(buf[38:46], e.Meta.BucketId)
+func (e *Entry) setEntryHeaderBuf(buf []byte) int {
+	index := 4
 
-	return buf
+	index += binary.PutUvarint(buf[index:], e.Meta.Timestamp)
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.KeySize))
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.ValueSize))
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.Flag))
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.TTL))
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.Status))
+	index += binary.PutUvarint(buf[index:], uint64(e.Meta.Ds))
+	index += binary.PutUvarint(buf[index:], e.Meta.TxID)
+	index += binary.PutUvarint(buf[index:], e.Meta.BucketId)
+
+	return index
 }
 
 // IsZero checks if the entry is zero or not.
@@ -142,20 +171,57 @@ func (e *Entry) ParsePayload(data []byte) error {
 // checkPayloadSize checks the payload size
 func (e *Entry) checkPayloadSize(size int64) error {
 	if e.Meta.PayloadSize() != size {
-		return payLoadSizeMismatchErr
+		return ErrPayLoadSizeMismatch
 	}
 	return nil
 }
 
 // ParseMeta parse Meta object to entry
-func (e *Entry) ParseMeta(buf []byte) error {
-	e.Meta = NewMetaData().WithCrc(binary.LittleEndian.Uint32(buf[0:4])).
-		WithTimeStamp(binary.LittleEndian.Uint64(buf[4:12])).WithKeySize(binary.LittleEndian.Uint32(buf[12:16])).
-		WithValueSize(binary.LittleEndian.Uint32(buf[16:20])).WithFlag(binary.LittleEndian.Uint16(buf[20:22])).
-		WithTTL(binary.LittleEndian.Uint32(buf[22:26])).
-		WithStatus(binary.LittleEndian.Uint16(buf[26:28])).WithDs(binary.LittleEndian.Uint16(buf[28:30])).
-		WithTxID(binary.LittleEndian.Uint64(buf[30:38])).WithBucketId(binary.LittleEndian.Uint64(buf[38:46]))
-	return nil
+func (e *Entry) ParseMeta(buf []byte) (int, error) {
+	// If the length of the header is less than MinEntryHeaderSize,
+	// it means that the final remaining capacity of the file is not enough to write a record,
+	// and an error needs to be returned.
+	if len(buf) < MinEntryHeaderSize {
+		return 0, ErrHeaderSizeOutOfBounds
+	}
+
+	e.Meta = NewMetaData()
+
+	e.Meta.WithCrc(binary.LittleEndian.Uint32(buf[0:4]))
+
+	index := 4
+
+	timestamp, n := binary.Uvarint(buf[index:])
+	index += n
+	keySize, n := binary.Uvarint(buf[index:])
+	index += n
+	valueSize, n := binary.Uvarint(buf[index:])
+	index += n
+	flag, n := binary.Uvarint(buf[index:])
+	index += n
+	ttl, n := binary.Uvarint(buf[index:])
+	index += n
+	status, n := binary.Uvarint(buf[index:])
+	index += n
+	ds, n := binary.Uvarint(buf[index:])
+	index += n
+	txId, n := binary.Uvarint(buf[index:])
+	index += n
+	bucketId, n := binary.Uvarint(buf[index:])
+	index += n
+
+	e.Meta.
+		WithTimeStamp(timestamp).
+		WithKeySize(uint32(keySize)).
+		WithValueSize(uint32(valueSize)).
+		WithFlag(uint16(flag)).
+		WithTTL(uint32(ttl)).
+		WithStatus(uint16(status)).
+		WithDs(uint16(ds)).
+		WithTxID(txId).
+		WithBucketId(bucketId)
+
+	return index, nil
 }
 
 // isFilter to confirm if this entry is can be filtered

--- a/entry_test.go
+++ b/entry_test.go
@@ -36,7 +36,7 @@ func (suite *EntryTestSuite) SetupSuite() {
 		Meta: NewMetaData().WithKeySize(uint32(len("key_0001"))).
 			WithValueSize(uint32(len("val_0001"))).WithTimeStamp(1547707905).WithTTL(Persistent).WithFlag(DataSetFlag).WithBucketId(1),
 	}
-	suite.expectedEncode = []byte{228, 252, 145, 200, 1, 38, 64, 92, 0, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 107, 101, 121, 95, 48, 48, 48, 49, 118, 97, 108, 95, 48, 48, 48, 49}
+	suite.expectedEncode = []byte{168, 1, 59, 122, 129, 204, 128, 226, 5, 8, 8, 1, 0, 0, 0, 0, 1, 107, 101, 121, 95, 48, 48, 48, 49, 118, 97, 108, 95, 48, 48, 48, 49}
 }
 
 func (suite *EntryTestSuite) TestEncode() {
@@ -54,7 +54,8 @@ func (suite *EntryTestSuite) TestIsZero() {
 
 func (suite *EntryTestSuite) TestGetCrc() {
 
-	crc1 := suite.entry.GetCrc(suite.expectedEncode[:DataEntryHeaderSize])
+	headerSize := suite.entry.Meta.Size()
+	crc1 := suite.entry.GetCrc(suite.expectedEncode[:headerSize])
 	crc2 := binary.LittleEndian.Uint32(suite.expectedEncode[:4])
 
 	if crc1 != crc2 {

--- a/merge.go
+++ b/merge.go
@@ -107,7 +107,7 @@ func (db *DB) merge() error {
 		}
 
 		for {
-			if entry, err := fr.readEntry(); err == nil {
+			if entry, err := fr.readEntry(off); err == nil {
 				if entry == nil {
 					break
 				}
@@ -164,7 +164,7 @@ func (db *DB) merge() error {
 				}
 
 			} else {
-				if errors.Is(err, io.EOF) || errors.Is(err, ErrIndexOutOfBound) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if errors.Is(err, io.EOF) || errors.Is(err, ErrIndexOutOfBound) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, ErrHeaderSizeOutOfBounds) {
 					break
 				}
 				return fmt.Errorf("when merge operation build hintIndex readAt err: %s", err)

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -64,7 +64,7 @@ func (fr *fileRecovery) readEntry(off int64) (e *Entry, err error) {
 
 	payloadSize := e.Meta.PayloadSize()
 	dataBuf := make([]byte, payloadSize)
-	excessSize := MaxEntryHeaderSize - headerSize
+	excessSize := size - headerSize
 
 	if payloadSize <= excessSize {
 		copy(dataBuf, remainingBuf[:payloadSize])

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -24,10 +24,10 @@ func Test_readEntry(t *testing.T) {
 	f, err := newFileRecovery(path, 4096)
 	require.NoError(t, err)
 
-	get, err := f.readEntry()
+	entry, err := f.readEntry(0)
 	require.NoError(t, err)
 
-	assert.Equal(t, expect.Encode(), get.Encode())
+	assert.Equal(t, expect.Encode(), entry.Encode())
 
 	err = fd.Close()
 	require.NoError(t, err)

--- a/rwmanager.go
+++ b/rwmanager.go
@@ -31,5 +31,6 @@ type RWManager interface {
 	ReadAt(b []byte, off int64) (n int, err error)
 	Sync() (err error)
 	Release() (err error)
+	Size() int64
 	Close() (err error)
 }

--- a/rwmanager_fileio_test.go
+++ b/rwmanager_fileio_test.go
@@ -21,7 +21,7 @@ func TestRWManager_FileIO_All(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		rwManager := &FileIORWManager{fd, filePath, fdm}
+		rwManager := &FileIORWManager{fd, filePath, fdm, 256 * MB}
 		b := []byte("hello")
 		off := int64(3)
 		_, err = rwManager.WriteAt(b, off)

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestRWManager_MMap_Release(t *testing.T) {
 	filePath := "/tmp/foo_rw_MMap"
-	fdm := newFileManager(MMap, 1024, 0.5)
-	rwmanager, err := fdm.getMMapRWManager(filePath, 1024)
+	fdm := newFileManager(MMap, 1024, 0.5, 256*MB)
+	rwmanager, err := fdm.getMMapRWManager(filePath, 1024, 256*MB)
 	if err != nil {
 		t.Error("err TestRWManager_MMap_Release getMMapRWManager")
 	}
@@ -78,7 +78,7 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mmManager := &MMapRWManager{filePath, fdm, m}
+	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
 	b := []byte("test write at")
 	off := int64(3)
 	n, err := mmManager.WriteAt(b, off)
@@ -111,7 +111,7 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mmManager := &MMapRWManager{filePath, fdm, m}
+	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
 	m[1] = 'z'
 	err = mmManager.Sync()
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestRWManager_MMap_Close(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mmManager := &MMapRWManager{filePath, fdm, m}
+	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
 	err = mmManager.Close()
 	err = isFileDescriptorClosed(fd.Fd())
 	if err == nil {

--- a/rwmanger_fileio.go
+++ b/rwmanger_fileio.go
@@ -20,9 +20,10 @@ import (
 
 // FileIORWManager represents the RWManager which using standard I/O.
 type FileIORWManager struct {
-	fd   *os.File
-	path string
-	fdm  *fdManager
+	fd          *os.File
+	path        string
+	fdm         *fdManager
+	segmentSize int64
 }
 
 // WriteAt writes len(b) bytes to the File starting at byte offset off.
@@ -49,6 +50,10 @@ func (fm *FileIORWManager) Sync() (err error) {
 func (fm *FileIORWManager) Release() (err error) {
 	fm.fdm.reduceUsing(fm.path)
 	return nil
+}
+
+func (fm *FileIORWManager) Size() int64 {
+	return fm.segmentSize
 }
 
 // Close will remove the cache in the fdm of the specified path, and call the close method of the os of the file

--- a/rwmanger_mmap.go
+++ b/rwmanger_mmap.go
@@ -22,9 +22,10 @@ import (
 
 // MMapRWManager represents the RWManager which using mmap.
 type MMapRWManager struct {
-	path string
-	fdm  *fdManager
-	m    mmap.MMap
+	path        string
+	fdm         *fdManager
+	m           mmap.MMap
+	segmentSize int64
 }
 
 var (
@@ -68,6 +69,10 @@ func (mm *MMapRWManager) Sync() (err error) {
 func (mm *MMapRWManager) Release() (err error) {
 	mm.fdm.reduceUsing(mm.path)
 	return mm.m.Unmap()
+}
+
+func (mm *MMapRWManager) Size() int64 {
+	return mm.segmentSize
 }
 
 // Close will remove the cache in the fdm of the specified path, and call the close method of the os of the file

--- a/tx.go
+++ b/tx.go
@@ -498,19 +498,14 @@ func (tx *Tx) getEntryNewAddRecordCount(entry *Entry) (int64, error) {
 }
 
 func (tx *Tx) allocCommitBuffer() *bytes.Buffer {
-	var txSize int64
-	for i := 0; i < len(tx.pendingWrites); i++ {
-		txSize += tx.pendingWrites[i].Size()
-	}
-
 	var buff *bytes.Buffer
 
-	if txSize < tx.db.opt.CommitBufferSize {
+	if tx.size < tx.db.opt.CommitBufferSize {
 		buff = tx.db.commitBuffer
 	} else {
 		buff = new(bytes.Buffer)
 		// avoid grow
-		buff.Grow(int(txSize))
+		buff.Grow(int(tx.size))
 	}
 
 	return buff

--- a/utils.go
+++ b/utils.go
@@ -169,3 +169,12 @@ func createNewBufferWithSize(size int) *bytes.Buffer {
 	buf.Grow(int(size))
 	return buf
 }
+
+func UvarintSize(x uint64) int {
+	i := 0
+	for x >= 0x80 {
+		x >>= 7
+		i++
+	}
+	return i + 1
+}


### PR DESCRIPTION
Using variable length encoding to store data can save a lot of disk space.https://github.com/nutsdb/nutsdb/issues/494

But since bufio does not provide a Seek interface, I temporarily chose to use os.File in the readEntry method of fileRecovery to read data. This may affect the performance at startup, but at the same time the number of bytes to be read at startup is also Less.