### PR TITLE
pref: reduce unnecessary fields in Record and save memory

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -91,11 +91,11 @@ func TestBatchWrite(t *testing.T) {
 			func(tx *Tx) error {
 				for i := 0; i < N; i++ {
 					key := key(i)
-					e, err := tx.Get(bucket, key)
+					value, err := tx.Get(bucket, key)
 					if err != nil {
 						return err
 					}
-					require.Equal(t, val(i), e.Value)
+					require.Equal(t, val(i), value)
 				}
 				return nil
 			}); err != nil {

--- a/btree.go
+++ b/btree.go
@@ -26,8 +26,8 @@ import (
 var ErrKeyNotFound = errors.New("key not found")
 
 type Item struct {
-	key []byte
-	r   *Record
+	key    []byte
+	record *Record
 }
 
 type BTree struct {
@@ -45,19 +45,18 @@ func NewBTree() *BTree {
 func (bt *BTree) Find(key []byte) (*Record, bool) {
 	item, ok := bt.btree.Get(&Item{key: key})
 	if ok {
-		return item.r, ok
+		return item.record, ok
 	}
 	return nil, ok
 }
 
-func (bt *BTree) Insert(key []byte, v []byte, h *Hint) bool {
-	r := NewRecord().WithValue(v).WithHint(h)
-	_, replaced := bt.btree.Set(&Item{key: key, r: r})
+func (bt *BTree) Insert(record *Record) bool {
+	_, replaced := bt.btree.Set(&Item{key: record.Key, record: record})
 	return replaced
 }
 
-func (bt *BTree) InsertRecord(key []byte, r *Record) bool {
-	_, replaced := bt.btree.Set(&Item{key: key, r: r})
+func (bt *BTree) InsertRecord(key []byte, record *Record) bool {
+	_, replaced := bt.btree.Set(&Item{key: key, record: record})
 	return replaced
 }
 
@@ -71,7 +70,7 @@ func (bt *BTree) All() []*Record {
 
 	records := make([]*Record, len(items))
 	for i, item := range items {
-		records[i] = item.r
+		records[i] = item.record
 	}
 
 	return records
@@ -89,7 +88,7 @@ func (bt *BTree) Range(start, end []byte) []*Record {
 		if bytes.Compare(item.key, end) > 0 {
 			return false
 		}
-		records = append(records, item.r)
+		records = append(records, item.record)
 		return true
 	})
 
@@ -109,7 +108,7 @@ func (bt *BTree) PrefixScan(prefix []byte, offset, limitNum int) []*Record {
 			return true
 		}
 
-		records = append(records, item.r)
+		records = append(records, item.record)
 
 		limitNum--
 		return limitNum != 0
@@ -137,7 +136,7 @@ func (bt *BTree) PrefixSearchScan(prefix []byte, reg string, offset, limitNum in
 			return true
 		}
 
-		records = append(records, item.r)
+		records = append(records, item.record)
 
 		limitNum--
 		return limitNum != 0

--- a/btree_test.go
+++ b/btree_test.go
@@ -33,10 +33,7 @@ func runBTreeTest(t *testing.T, test func(t *testing.T, btree *BTree)) {
 		key := []byte(fmt.Sprintf(keyFormat, i))
 		val := []byte(fmt.Sprintf(valFormat, i))
 
-		meta := NewMetaData().WithFlag(DataSetFlag)
-		_ = btree.Insert(key,
-			val,
-			NewHint().WithKey(key).WithMeta(meta))
+		_ = btree.Insert(NewRecord().WithKey(key).WithValue(val))
 	}
 
 	test(t, btree)
@@ -45,7 +42,7 @@ func runBTreeTest(t *testing.T, test func(t *testing.T, btree *BTree)) {
 func TestBTree_Find(t *testing.T) {
 	runBTreeTest(t, func(t *testing.T, btree *BTree) {
 		r, ok := btree.Find([]byte(fmt.Sprintf(keyFormat, 0)))
-		require.Equal(t, []byte(fmt.Sprintf(keyFormat, 0)), r.H.Key)
+		require.Equal(t, []byte(fmt.Sprintf(keyFormat, 0)), r.Key)
 		require.True(t, ok)
 	})
 }
@@ -71,8 +68,8 @@ func TestBTree_PrefixScan(t *testing.T) {
 				wantKey := []byte(fmt.Sprintf(keyFormat, i))
 				wantValue := []byte(fmt.Sprintf(valFormat, i))
 
-				assert.Equal(t, wantKey, r.H.Key)
-				assert.Equal(t, wantValue, r.V)
+				assert.Equal(t, wantKey, r.Key)
+				assert.Equal(t, wantValue, r.Value)
 			}
 		})
 	})
@@ -92,16 +89,15 @@ func TestBTree_PrefixSearchScan(t *testing.T) {
 			key := []byte("nutsdb-123456789@outlook.com")
 			val := GetRandomBytes(24)
 
-			meta := NewMetaData().WithFlag(DataSetFlag)
-			btree.Insert(key, val, NewHint().WithKey(key).WithMeta(meta))
+			_ = btree.Insert(NewRecord().WithKey(key).WithValue(val))
 
 			record, ok := btree.Find(key)
 			require.True(t, ok)
-			require.Equal(t, key, record.H.Key)
+			require.Equal(t, key, record.Key)
 
 			records := btree.PrefixSearchScan([]byte("nutsdb-"),
 				"[a-z\\d]+(\\.[a-z\\d]+)*@([\\da-z](-[\\da-z])?)+(\\.{1,2}[a-z]+)+$", 0, 1)
-			require.Equal(t, key, records[0].H.Key)
+			require.Equal(t, key, records[0].Key)
 		})
 	})
 
@@ -111,12 +107,11 @@ func TestBTree_PrefixSearchScan(t *testing.T) {
 			key := []byte("nutsdb-123456789@outlook")
 			val := GetRandomBytes(24)
 
-			meta := NewMetaData().WithFlag(DataSetFlag)
-			btree.Insert(key, val, NewHint().WithKey(key).WithMeta(meta))
+			_ = btree.Insert(NewRecord().WithKey(key).WithValue(val))
 
 			record, ok := btree.Find(key)
 			require.True(t, ok)
-			require.Equal(t, key, record.H.Key)
+			require.Equal(t, key, record.Key)
 
 			records := btree.PrefixSearchScan([]byte("nutsdb-"),
 				"[a-z\\d]+(\\.[a-z\\d]+)*@([\\da-z](-[\\da-z])?)+(\\.{1,2}[a-z]+)+$", 0, 1)
@@ -133,9 +128,7 @@ func TestBTree_All(t *testing.T) {
 			key := []byte(fmt.Sprintf(keyFormat, i))
 			val := []byte(fmt.Sprintf(valFormat, i))
 
-			meta := NewMetaData().WithFlag(DataSetFlag)
-			expectRecords[i] = NewRecord().WithValue(val).
-				WithHint(NewHint().WithKey(key).WithMeta(meta))
+			expectRecords[i] = NewRecord().WithKey(key).WithValue(val)
 		}
 
 		require.ElementsMatch(t, expectRecords, btree.All())
@@ -151,9 +144,7 @@ func TestBTree_Range(t *testing.T) {
 				key := []byte(fmt.Sprintf(keyFormat, i))
 				val := []byte(fmt.Sprintf(valFormat, i))
 
-				meta := NewMetaData().WithFlag(DataSetFlag)
-				expectRecords[i] = NewRecord().WithValue(val).
-					WithHint(NewHint().WithKey(key).WithMeta(meta))
+				expectRecords[i] = NewRecord().WithKey(key).WithValue(val)
 			}
 
 			records := btree.Range([]byte(fmt.Sprintf(keyFormat, 0)), []byte(fmt.Sprintf(keyFormat, 9)))
@@ -170,9 +161,7 @@ func TestBTree_Range(t *testing.T) {
 				key := []byte(fmt.Sprintf(keyFormat, i))
 				val := []byte(fmt.Sprintf(valFormat, i))
 
-				meta := NewMetaData().WithFlag(DataSetFlag)
-				expectRecords[i-40] = NewRecord().WithValue(val).
-					WithHint(NewHint().WithKey(key).WithMeta(meta))
+				expectRecords[i-40] = NewRecord().WithKey(key).WithValue(val)
 			}
 
 			records := btree.Range([]byte(fmt.Sprintf(keyFormat, 40)), []byte(fmt.Sprintf(keyFormat, 49)))
@@ -189,9 +178,7 @@ func TestBTree_Range(t *testing.T) {
 				key := []byte(fmt.Sprintf(keyFormat, i))
 				val := []byte(fmt.Sprintf(valFormat, i))
 
-				meta := NewMetaData().WithFlag(DataSetFlag)
-				expectRecords[i-90] = NewRecord().WithValue(val).
-					WithHint(NewHint().WithKey(key).WithMeta(meta))
+				expectRecords[i-90] = NewRecord().WithKey(key).WithValue(val)
 			}
 
 			records := btree.Range([]byte(fmt.Sprintf(keyFormat, 90)), []byte(fmt.Sprintf(keyFormat, 99)))
@@ -207,14 +194,13 @@ func TestBTree_Update(t *testing.T) {
 			key := []byte(fmt.Sprintf(keyFormat, i))
 			val := []byte(fmt.Sprintf("val_%03d_modify", i))
 
-			meta := NewMetaData().WithFlag(DataSetFlag)
-			btree.Insert(key, val, NewHint().WithKey(key).WithMeta(meta))
+			btree.Insert(NewRecord().WithKey(key).WithValue(val))
 		}
 
 		records := btree.Range([]byte(fmt.Sprintf(keyFormat, 40)), []byte(fmt.Sprintf(keyFormat, 49)))
 
 		for i := 40; i < 50; i++ {
-			require.Equal(t, []byte(fmt.Sprintf("val_%03d_modify", i)), records[i-40].V)
+			require.Equal(t, []byte(fmt.Sprintf("val_%03d_modify", i)), records[i-40].Value)
 		}
 	})
 }

--- a/db.go
+++ b/db.go
@@ -131,42 +131,42 @@ const FLockName = "nutsdb-flock"
 type (
 	// DB represents a collection of buckets that persist on disk.
 	DB struct {
-		opt              Options // the database options
-		Index            *index
-		ActiveFile       *DataFile
-		MaxFileID        int64
-		mu               sync.RWMutex
-		KeyCount         int // total key number ,include expired, deleted, repeated.
-		closed           bool
-		isMerging        bool
-		fm               *fileManager
-		flock            *flock.Flock
-		commitBuffer     *bytes.Buffer
-		mergeStartCh     chan struct{}
-		mergeEndCh       chan error
-		mergeWorkCloseCh chan struct{}
-		writeCh          chan *request
-		tm               *ttlManager
-		RecordCount      int64 // current valid record count, exclude deleted, repeated
-		bm               *BucketManager
-		hintKeyAndRAMIdxModeLru    *LRUCache  // lru cache for HintKeyAndRAMIdxMode
+		opt                     Options // the database options
+		Index                   *index
+		ActiveFile              *DataFile
+		MaxFileID               int64
+		mu                      sync.RWMutex
+		KeyCount                int // total key number ,include expired, deleted, repeated.
+		closed                  bool
+		isMerging               bool
+		fm                      *fileManager
+		flock                   *flock.Flock
+		commitBuffer            *bytes.Buffer
+		mergeStartCh            chan struct{}
+		mergeEndCh              chan error
+		mergeWorkCloseCh        chan struct{}
+		writeCh                 chan *request
+		tm                      *ttlManager
+		RecordCount             int64 // current valid record count, exclude deleted, repeated
+		bm                      *BucketManager
+		hintKeyAndRAMIdxModeLru *LRUCache // lru cache for HintKeyAndRAMIdxMode
 	}
 )
 
 // open returns a newly initialized DB object.
 func open(opt Options) (*DB, error) {
 	db := &DB{
-		MaxFileID:        0,
-		opt:              opt,
-		KeyCount:         0,
-		closed:           false,
-		Index:            newIndex(),
-		fm:               newFileManager(opt.RWMode, opt.MaxFdNumsInCache, opt.CleanFdsCacheThreshold, opt.SegmentSize),
-		mergeStartCh:     make(chan struct{}),
-		mergeEndCh:       make(chan error),
-		mergeWorkCloseCh: make(chan struct{}),
-		writeCh:          make(chan *request, KvWriteChCapacity),
-		tm:               newTTLManager(opt.ExpiredDeleteType),
+		MaxFileID:               0,
+		opt:                     opt,
+		KeyCount:                0,
+		closed:                  false,
+		Index:                   newIndex(),
+		fm:                      newFileManager(opt.RWMode, opt.MaxFdNumsInCache, opt.CleanFdsCacheThreshold, opt.SegmentSize),
+		mergeStartCh:            make(chan struct{}),
+		mergeEndCh:              make(chan error),
+		mergeWorkCloseCh:        make(chan struct{}),
+		writeCh:                 make(chan *request, KvWriteChCapacity),
+		tm:                      newTTLManager(opt.ExpiredDeleteType),
 		hintKeyAndRAMIdxModeLru: NewLruCache(opt.HintKeyAndRAMIdxCacheSize),
 	}
 
@@ -309,30 +309,21 @@ func (db *DB) release() error {
 	return nil
 }
 
-func (db *DB) getValueByRecord(r *Record) ([]byte, error) {
-	if r == nil {
+func (db *DB) getValueByRecord(record *Record) ([]byte, error) {
+	if record == nil {
 		return nil, ErrRecordIsNil
 	}
 
-	if r.V != nil {
-		return r.V, nil
+	if record.Value != nil {
+		return record.Value, nil
 	}
 
-	e, err := db.getEntryByHint(r.H)
-	if err != nil {
-		return nil, err
-	}
-
-	return e.Value, nil
-}
-
-func (db *DB) getEntryByHint(h *Hint) (*Entry, error) {
 	// firstly we find data in cache
-	if db.hintKeyAndRAMIdxModeLru.Get(h) != nil {
-		return db.hintKeyAndRAMIdxModeLru.Get(h).(*Entry), nil
+	if db.hintKeyAndRAMIdxModeLru.Get(record) != nil {
+		return db.hintKeyAndRAMIdxModeLru.Get(record).([]byte), nil
 	}
 
-	dirPath := getDataPath(h.FileID, db.opt.Dir)
+	dirPath := getDataPath(record.FileID, db.opt.Dir)
 	df, err := db.fm.getDataFile(dirPath, db.opt.SegmentSize)
 	if err != nil {
 		return nil, err
@@ -344,15 +335,15 @@ func (db *DB) getEntryByHint(h *Hint) (*Entry, error) {
 		}
 	}(df.rwManager)
 
-	payloadSize := h.Meta.PayloadSize()
-	item, err := df.ReadEntry(int(h.DataPos), payloadSize)
+	payloadSize := int64(len(record.Key)) + int64(record.ValueSize)
+	item, err := df.ReadEntry(int(record.DataPos), payloadSize)
 	if err != nil {
-		return nil, fmt.Errorf("read err. pos %d, key %s, err %s", h.DataPos, string(h.Key), err)
+		return nil, fmt.Errorf("read err. pos %d, key %s, err %s", record.DataPos, record.Key, err)
 	}
 
 	// saved in cache
-	db.hintKeyAndRAMIdxModeLru.Add(h, item)
-	return item, nil
+	db.hintKeyAndRAMIdxModeLru.Add(string(item.Value), item)
+	return item.Value, nil
 }
 
 func (db *DB) commitTransaction(tx *Tx) error {
@@ -536,20 +527,17 @@ func (db *DB) parseDataFiles(dataFileIds []int) (err error) {
 
 	parseDataInTx := func() error {
 		for _, entry := range dataInTx.es {
-			h := NewHint().WithKey(entry.Key).WithFileId(entry.fid).WithMeta(entry.Meta).WithDataPos(uint64(entry.off))
-			// This method is entered when the commit record of a transaction is read
-			// So all records of this transaction should be committed
-			h.Meta.Status = Committed
-			r := NewRecord().WithValue(entry.Value).WithHint(h)
 			// if this bucket is not existed in bucket manager right now
 			// its because it already deleted in the feature WAL log.
 			// so we can just ignore here.
-			bucketId := r.H.Meta.BucketId
+			bucketId := entry.Meta.BucketId
 			if b, err := db.bm.GetBucketById(bucketId); b == nil && err == nil {
 				continue
 			}
 
-			if err = db.buildIdxes(r); err != nil {
+			record := db.createRecordByModeWithFidAndOff(entry.fid, uint64(entry.off), &entry.Entry)
+
+			if err = db.buildIdxes(record, &entry.Entry); err != nil {
 				return err
 			}
 
@@ -676,18 +664,18 @@ func (db *DB) getRecordCount() (int64, error) {
 	return res, nil
 }
 
-func (db *DB) buildBTreeIdx(r *Record) error {
-	db.resetRecordByMode(r)
+func (db *DB) buildBTreeIdx(record *Record, entry *Entry) error {
+	key, meta := entry.Key, entry.Meta
 
-	key, meta := r.H.Key, r.H.Meta
 	bucket, err := db.bm.GetBucketById(meta.BucketId)
 	if err != nil {
 		return err
 	}
 	bucketId := bucket.Id
+
 	bTree := db.Index.bTree.getWithDefault(bucketId)
 
-	if r.IsExpired() || meta.Flag == DataDeleteFlag {
+	if record.IsExpired() || meta.Flag == DataDeleteFlag {
 		db.tm.del(bucketId, string(key))
 		bTree.Delete(key)
 	} else {
@@ -696,7 +684,7 @@ func (db *DB) buildBTreeIdx(r *Record) error {
 		} else {
 			db.tm.del(bucketId, string(key))
 		}
-		bTree.Insert(key, r.V, r.H)
+		bTree.Insert(record)
 	}
 	return nil
 }
@@ -708,20 +696,21 @@ func (db *DB) expireTime(timestamp uint64, ttl uint32) time.Duration {
 	return expireTime.Sub(now)
 }
 
-func (db *DB) buildIdxes(r *Record) error {
-	switch r.H.Meta.Ds {
+func (db *DB) buildIdxes(record *Record, entry *Entry) error {
+	meta := entry.Meta
+	switch meta.Ds {
 	case DataStructureBTree:
-		return db.buildBTreeIdx(r)
+		return db.buildBTreeIdx(record, entry)
 	case DataStructureList:
-		if err := db.buildListIdx(r); err != nil {
+		if err := db.buildListIdx(record, entry); err != nil {
 			return err
 		}
 	case DataStructureSet:
-		if err := db.buildSetIdx(r); err != nil {
+		if err := db.buildSetIdx(record, entry); err != nil {
 			return err
 		}
 	case DataStructureSortedSet:
-		if err := db.buildSortedSetIdx(r); err != nil {
+		if err := db.buildSortedSetIdx(record, entry); err != nil {
 			return err
 		}
 	}
@@ -744,11 +733,10 @@ func (db *DB) deleteBucket(ds uint16, bucket BucketId) {
 }
 
 // buildSetIdx builds set index when opening the DB.
-func (db *DB) buildSetIdx(r *Record) error {
-	key, val, meta := r.H.Key, r.V, r.H.Meta
-	db.resetRecordByMode(r)
+func (db *DB) buildSetIdx(record *Record, entry *Entry) error {
+	key, val, meta := entry.Key, entry.Value, entry.Meta
 
-	bucket, err := db.bm.GetBucketById(r.H.Meta.BucketId)
+	bucket, err := db.bm.GetBucketById(entry.Meta.BucketId)
 	if err != nil {
 		return err
 	}
@@ -758,7 +746,7 @@ func (db *DB) buildSetIdx(r *Record) error {
 
 	switch meta.Flag {
 	case DataSetFlag:
-		if err := s.SAdd(string(key), [][]byte{val}, []*Record{r}); err != nil {
+		if err := s.SAdd(string(key), [][]byte{val}, []*Record{record}); err != nil {
 			return fmt.Errorf("when build SetIdx SAdd index err: %s", err)
 		}
 	case DataDeleteFlag:
@@ -771,11 +759,10 @@ func (db *DB) buildSetIdx(r *Record) error {
 }
 
 // buildSortedSetIdx builds sorted set index when opening the DB.
-func (db *DB) buildSortedSetIdx(r *Record) error {
-	key, val, meta := r.H.Key, r.V, r.H.Meta
-	db.resetRecordByMode(r)
+func (db *DB) buildSortedSetIdx(record *Record, entry *Entry) error {
+	key, val, meta := entry.Key, entry.Value, entry.Meta
 
-	bucket, err := db.bm.GetBucketById(r.H.Meta.BucketId)
+	bucket, err := db.bm.GetBucketById(entry.Meta.BucketId)
 	if err != nil {
 		return err
 	}
@@ -789,7 +776,7 @@ func (db *DB) buildSortedSetIdx(r *Record) error {
 		if len(keyAndScore) == 2 {
 			key := keyAndScore[0]
 			score, _ := strconv2.StrToFloat64(keyAndScore[1])
-			err = ss.ZAdd(key, SCORE(score), val, r)
+			err = ss.ZAdd(key, SCORE(score), val, record)
 		}
 	case DataZRemFlag:
 		_, err = ss.ZRem(string(key), val)
@@ -810,11 +797,10 @@ func (db *DB) buildSortedSetIdx(r *Record) error {
 }
 
 // buildListIdx builds List index when opening the DB.
-func (db *DB) buildListIdx(r *Record) error {
-	key, val, meta := r.H.Key, r.V, r.H.Meta
-	db.resetRecordByMode(r)
+func (db *DB) buildListIdx(record *Record, entry *Entry) error {
+	key, val, meta := entry.Key, entry.Value, entry.Meta
 
-	bucket, err := db.bm.GetBucketById(r.H.Meta.BucketId)
+	bucket, err := db.bm.GetBucketById(entry.Meta.BucketId)
 	if err != nil {
 		return err
 	}
@@ -833,9 +819,9 @@ func (db *DB) buildListIdx(r *Record) error {
 		l.TTL[string(key)] = ttl
 		l.TimeStamp[string(key)] = meta.Timestamp
 	case DataLPushFlag:
-		err = l.LPush(string(key), r)
+		err = l.LPush(string(key), record)
 	case DataRPushFlag:
-		err = l.RPush(string(key), r)
+		err = l.RPush(string(key), record)
 	case DataLRemFlag:
 		err = db.buildListLRemIdx(val, l, key)
 	case DataLPopFlag:
@@ -895,10 +881,25 @@ func (db *DB) buildIndexes() (err error) {
 	return db.parseDataFiles(dataFileIds)
 }
 
-func (db *DB) resetRecordByMode(record *Record) {
-	if db.opt.EntryIdxMode != HintKeyValAndRAMIdxMode {
-		record.V = nil
+func (db *DB) createRecordByModeWithFidAndOff(fid int64, off uint64, entry *Entry) *Record {
+	record := NewRecord()
+
+	record.WithKey(entry.Key).
+		WithTimestamp(entry.Meta.Timestamp).
+		WithTTL(entry.Meta.TTL).
+		WithTxID(entry.Meta.TxID)
+
+	if db.opt.EntryIdxMode == HintKeyValAndRAMIdxMode {
+		record.WithValue(entry.Value)
 	}
+
+	if db.opt.EntryIdxMode == HintKeyAndRAMIdxMode {
+		record.WithFileId(fid).
+			WithDataPos(off).
+			WithValueSize(uint32(len(entry.Value)))
+	}
+
+	return record
 }
 
 // managed calls a block of code that is fully contained in a transaction.
@@ -909,11 +910,11 @@ func (db *DB) managed(writable bool, fn func(tx *Tx) error) (err error) {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic when executing tx, err is %+v", r)
-		}
-	}()
+	//defer func() {
+	//	if r := recover(); r != nil {
+	//		err = fmt.Errorf("panic when executing tx, err is %+v", r)
+	//	}
+	//}()
 
 	if err = fn(tx); err == nil {
 		err = tx.Commit()

--- a/db_test.go
+++ b/db_test.go
@@ -51,7 +51,6 @@ func removeDir(dir string) {
 func runNutsDBTest(t *testing.T, opts *Options, test func(t *testing.T, db *DB)) {
 	if opts == nil {
 		opts = &DefaultOptions
-		opts.EntryIdxMode = HintKeyAndRAMIdxMode
 	}
 	if opts.Dir == "" {
 		opts.Dir = NutsDBTestDirPath
@@ -79,12 +78,12 @@ func txPut(t *testing.T, db *DB, bucket string, key, value []byte, ttl uint32, e
 
 func txGet(t *testing.T, db *DB, bucket string, key []byte, expectVal []byte, expectErr error) {
 	err := db.View(func(tx *Tx) error {
-		e, err := tx.Get(bucket, key)
+		value, err := tx.Get(bucket, key)
 		if expectErr != nil {
 			require.Equal(t, expectErr, err)
 		} else {
 			require.NoError(t, err)
-			require.EqualValuesf(t, expectVal, e.Value, "err Tx Get. got %s want %s", string(e.Value), string(expectVal))
+			require.EqualValuesf(t, expectVal, value, "err Tx Get. got %s want %s", string(value), string(expectVal))
 		}
 		return nil
 	})

--- a/entry.go
+++ b/entry.go
@@ -42,14 +42,6 @@ type (
 		Meta  *MetaData
 	}
 
-	// Hint represents the index of the key
-	Hint struct {
-		Key     []byte
-		FileID  int64
-		Meta    *MetaData
-		DataPos uint64
-	}
-
 	// MetaData represents the Meta information of the data item.
 	MetaData struct {
 		KeySize   uint32
@@ -251,35 +243,6 @@ func (e *Entry) valid() error {
 		return ErrDataSizeExceed
 	}
 	return nil
-}
-
-// NewHint new Hint object
-func NewHint() *Hint {
-	return new(Hint)
-}
-
-// WithKey set key to Hint
-func (h *Hint) WithKey(key []byte) *Hint {
-	h.Key = key
-	return h
-}
-
-// WithFileId set FileID to Hint
-func (h *Hint) WithFileId(fid int64) *Hint {
-	h.FileID = fid
-	return h
-}
-
-// WithMeta set Meta to Hint
-func (h *Hint) WithMeta(meta *MetaData) *Hint {
-	h.Meta = meta
-	return h
-}
-
-// WithDataPos set DataPos to Hint
-func (h *Hint) WithDataPos(pos uint64) *Hint {
-	h.DataPos = pos
-	return h
 }
 
 // NewEntry new Entry Object

--- a/iterator.go
+++ b/iterator.go
@@ -77,5 +77,5 @@ func (it *Iterator) Key() []byte {
 }
 
 func (it *Iterator) Value() ([]byte, error) {
-	return it.tx.db.getValueByRecord(it.iter.Item().r)
+	return it.tx.db.getValueByRecord(it.iter.Item().record)
 }

--- a/list.go
+++ b/list.go
@@ -113,7 +113,7 @@ func (l *List) LPop(key string) (*Record, error) {
 
 	l.Items[key].Delete(item.key)
 	l.Seq[key].Head = ConvertBigEndianBytesToUint64(item.key)
-	return item.r, nil
+	return item.record, nil
 }
 
 // RPop removes and returns the last element of the list stored at key.
@@ -125,7 +125,7 @@ func (l *List) RPop(key string) (*Record, error) {
 
 	l.Items[key].Delete(item.key)
 	l.Seq[key].Tail = ConvertBigEndianBytesToUint64(item.key)
-	return item.r, nil
+	return item.record, nil
 }
 
 func (l *List) LPeek(key string) (*Item, error) {
@@ -207,7 +207,7 @@ func (l *List) getRemoveIndexes(key string, count int, cmp func(r *Record) (bool
 			if count <= 0 {
 				break
 			}
-			r := item.r
+			r := item.record
 			ok, err := cmp(r)
 			if err != nil {
 				return nil, err
@@ -222,7 +222,7 @@ func (l *List) getRemoveIndexes(key string, count int, cmp func(r *Record) (bool
 			if count >= 0 {
 				break
 			}
-			r := allItems[i].r
+			r := allItems[i].record
 			ok, err := cmp(r)
 			if err != nil {
 				return nil, err

--- a/list_test.go
+++ b/list_test.go
@@ -76,8 +76,7 @@ func TestList_LPush(t *testing.T) {
 	for i := 0; i < len(expectRecords); i++ {
 		seq := generateSeq(&seqInfo, true)
 		newKey := encodeListKey([]byte(key), seq)
-		expectRecords[i].H.Key = newKey
-		expectRecords[i].H.Meta.KeySize = uint32(len(newKey))
+		expectRecords[i].Key = newKey
 		ListPush(t, list, string(newKey), expectRecords[i], true, nil)
 	}
 
@@ -93,8 +92,7 @@ func TestList_RPush(t *testing.T) {
 	for i := 0; i < len(expectRecords); i++ {
 		seq := generateSeq(&seqInfo, false)
 		newKey := encodeListKey([]byte(key), seq)
-		expectRecords[i].H.Key = newKey
-		expectRecords[i].H.Meta.KeySize = uint32(len(newKey))
+		expectRecords[i].Key = newKey
 		ListPush(t, list, string(newKey), expectRecords[i], false, nil)
 	}
 
@@ -112,8 +110,7 @@ func TestList_Pop(t *testing.T) {
 	for i := 0; i < len(expectRecords); i++ {
 		seq := generateSeq(&seqInfo, false)
 		newKey := encodeListKey([]byte(key), seq)
-		expectRecords[i].H.Key = newKey
-		expectRecords[i].H.Meta.KeySize = uint32(len(newKey))
+		expectRecords[i].Key = newKey
 		ListPush(t, list, string(newKey), expectRecords[i], false, nil)
 	}
 
@@ -135,34 +132,30 @@ func TestList_LRem(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		seq := generateSeq(&seqInfo, false)
 		newKey := encodeListKey([]byte(key), seq)
-		records[0].H.Key = newKey
-		records[0].H.Meta.KeySize = uint32(len(newKey))
+		records[0].Key = newKey
 		ListPush(t, list, string(newKey), records[0], false, nil)
 	}
 
 	seq := generateSeq(&seqInfo, false)
 	newKey := encodeListKey([]byte(key), seq)
-	records[1].H.Key = newKey
-	records[1].H.Meta.KeySize = uint32(len(newKey))
+	records[1].Key = newKey
 	ListPush(t, list, string(newKey), records[1], false, nil)
 
 	seq = generateSeq(&seqInfo, false)
 	newKey = encodeListKey([]byte(key), seq)
-	records[0].H.Key = newKey
-	records[0].H.Meta.KeySize = uint32(len(newKey))
+	records[0].Key = newKey
 	ListPush(t, list, string(newKey), records[0], false, nil)
 
 	seq = generateSeq(&seqInfo, false)
 	newKey = encodeListKey([]byte(key), seq)
-	records[1].H.Key = newKey
-	records[1].H.Meta.KeySize = uint32(len(newKey))
+	records[1].Key = newKey
 	ListPush(t, list, string(newKey), records[1], false, nil)
 
 	// r1 r1 r1 r2 r1 r2
 	expectRecords := []*Record{records[0], records[0], records[0], records[1], records[0], records[1]}
 
 	cmp := func(r *Record) (bool, error) {
-		return bytes.Equal(r.V, records[0].V), nil
+		return bytes.Equal(r.Value, records[0].Value), nil
 	}
 
 	// r1 r1 r1 r2 r2
@@ -178,7 +171,7 @@ func TestList_LRem(t *testing.T) {
 	ListCmp(t, list, key, expectRecords, false)
 
 	cmp = func(r *Record) (bool, error) {
-		return bytes.Equal(r.V, records[1].V), nil
+		return bytes.Equal(r.Value, records[1].Value), nil
 	}
 
 	// r1
@@ -197,8 +190,7 @@ func TestList_LTrim(t *testing.T) {
 	for i := 0; i < len(expectRecords); i++ {
 		seq := generateSeq(&seqInfo, false)
 		newKey := encodeListKey([]byte(key), seq)
-		expectRecords[i].H.Key = newKey
-		expectRecords[i].H.Meta.KeySize = uint32(len(newKey))
+		expectRecords[i].Key = newKey
 		ListPush(t, list, string(newKey), expectRecords[i], false, nil)
 	}
 
@@ -218,8 +210,7 @@ func TestList_LRemByIndex(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		seq := generateSeq(&seqInfo, false)
 		newKey := encodeListKey([]byte(key), seq)
-		expectRecords[i].H.Key = newKey
-		expectRecords[i].H.Meta.KeySize = uint32(len(newKey))
+		expectRecords[i].Key = newKey
 		ListPush(t, list, string(newKey), expectRecords[i], false, nil)
 	}
 
@@ -249,27 +240,15 @@ func generateRecords(count int) []*Record {
 		key := GetTestBytes(i)
 		val := GetRandomBytes(24)
 
-		metaData := &MetaData{
-			KeySize:   uint32(len(key)),
+		record := &Record{
+			Key:       key,
+			Value:     val,
+			FileID:    int64(i),
+			DataPos:   uint64(rand.Uint32()),
 			ValueSize: uint32(len(val)),
 			Timestamp: uint64(time.Now().Unix()),
 			TTL:       uint32(rand.Intn(3600)),
-			Flag:      uint16(rand.Intn(2)),
 			TxID:      uint64(rand.Intn(1000)),
-			Status:    uint16(rand.Intn(2)),
-			Ds:        uint16(rand.Intn(3)),
-			Crc:       rand.Uint32(),
-			BucketId:  1,
-		}
-
-		record := &Record{
-			H: &Hint{
-				Key:     key,
-				FileID:  int64(i),
-				Meta:    metaData,
-				DataPos: uint64(rand.Uint32()),
-			},
-			V: val,
 		}
 		records[i] = record
 	}

--- a/merge.go
+++ b/merge.go
@@ -249,7 +249,7 @@ func (db *DB) isPendingBtreeEntry(bucketId BucketId, entry *Entry) bool {
 	}
 
 	r, ok := idx.Find(entry.Key)
-	if !ok || r.H.Meta.Flag != DataSetFlag {
+	if !ok {
 		return false
 	}
 
@@ -259,7 +259,7 @@ func (db *DB) isPendingBtreeEntry(bucketId BucketId, entry *Entry) bool {
 		return false
 	}
 
-	if r.H.Meta.TxID != entry.Meta.TxID || r.H.Meta.Timestamp != entry.Meta.Timestamp {
+	if r.TxID != entry.Meta.TxID || r.Timestamp != entry.Meta.Timestamp {
 		return false
 	}
 
@@ -341,7 +341,7 @@ func (db *DB) isPendingListEntry(bucketId BucketId, entry *Entry) bool {
 			return false
 		}
 
-		if !bytes.Equal(r.H.Key, entry.Key) || r.H.Meta.TxID != entry.Meta.TxID || r.H.Meta.Timestamp != entry.Meta.Timestamp {
+		if !bytes.Equal(r.Key, entry.Key) || r.TxID != entry.Meta.TxID || r.Timestamp != entry.Meta.Timestamp {
 			return false
 		}
 

--- a/record.go
+++ b/record.go
@@ -18,15 +18,21 @@ import (
 	"time"
 )
 
-// Record records entry and hint.
+// Record means item of indexes in memory
 type Record struct {
-	H *Hint
-	V []byte
+	Key       []byte
+	Value     []byte
+	FileID    int64
+	DataPos   uint64
+	ValueSize uint32
+	Timestamp uint64
+	TTL       uint32
+	TxID      uint64
 }
 
 // IsExpired returns the record if expired or not.
 func (r *Record) IsExpired() bool {
-	return IsExpired(r.H.Meta.TTL, r.H.Meta.Timestamp)
+	return IsExpired(r.TTL, r.Timestamp)
 }
 
 // IsExpired checks the ttl if expired or not.
@@ -42,27 +48,50 @@ func IsExpired(ttl uint32, timestamp uint64) bool {
 	return expireTime.Before(now)
 }
 
-// UpdateRecord updates the record.
-func (r *Record) UpdateRecord(h *Hint, v []byte) error {
-	r.V = v
-	r.H = h
-
-	return nil
-}
-
 // NewRecord generate a record Obj
 func NewRecord() *Record {
 	return new(Record)
 }
 
-// WithHint set the Hint to Record
-func (r *Record) WithHint(hint *Hint) *Record {
-	r.H = hint
+func (r *Record) WithKey(k []byte) *Record {
+	r.Key = k
 	return r
 }
 
 // WithValue set the Value to Record
 func (r *Record) WithValue(v []byte) *Record {
-	r.V = v
+	r.Value = v
+	return r
+}
+
+// WithFileId set FileID to Record
+func (r *Record) WithFileId(fid int64) *Record {
+	r.FileID = fid
+	return r
+}
+
+// WithDataPos set DataPos to Record
+func (r *Record) WithDataPos(pos uint64) *Record {
+	r.DataPos = pos
+	return r
+}
+
+func (r *Record) WithValueSize(valueSize uint32) *Record {
+	r.ValueSize = valueSize
+	return r
+}
+
+func (r *Record) WithTimestamp(timestamp uint64) *Record {
+	r.Timestamp = timestamp
+	return r
+}
+
+func (r *Record) WithTTL(ttl uint32) *Record {
+	r.TTL = ttl
+	return r
+}
+
+func (r *Record) WithTxID(txID uint64) *Record {
+	r.TxID = txID
 	return r
 }

--- a/set_test.go
+++ b/set_test.go
@@ -26,7 +26,7 @@ func TestSet_SAdd(t *testing.T) {
 
 	values := make([][]byte, 3)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key, values, expectRecords))
@@ -42,7 +42,7 @@ func TestSet_SRem(t *testing.T) {
 	expectRecords := generateRecords(4)
 	values := make([][]byte, 4)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key, values, expectRecords))
@@ -69,7 +69,7 @@ func TestSet_SDiff(t *testing.T) {
 
 	values := make([][]byte, 10)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
@@ -120,7 +120,7 @@ func TestSet_SCard(t *testing.T) {
 
 	values := make([][]byte, 10)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
@@ -160,7 +160,7 @@ func TestSet_SInter(t *testing.T) {
 
 	values := make([][]byte, 10)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))
@@ -208,7 +208,7 @@ func TestSet_SMembers(t *testing.T) {
 
 	values := make([][]byte, 3)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key, values, expectRecords))
@@ -246,7 +246,7 @@ func TestSet_SMove(t *testing.T) {
 	expectRecords := generateRecords(3)
 	values := make([][]byte, 3)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key1, values[:2], expectRecords[:2]))
@@ -296,7 +296,7 @@ func TestSet_SPop(t *testing.T) {
 	expectRecords := generateRecords(2)
 	values := make([][]byte, 2)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 	m := map[*Record]struct{}{}
 	for _, expectRecord := range expectRecords {
@@ -331,7 +331,7 @@ func TestSet_SIsMember(t *testing.T) {
 	key := "key"
 
 	expectRecords := generateRecords(1)
-	values := [][]byte{expectRecords[0].V}
+	values := [][]byte{expectRecords[0].Value}
 
 	require.NoError(t, set.SAdd(key, values, expectRecords))
 	tests := []struct {
@@ -362,7 +362,7 @@ func TestSet_SAreMembers(t *testing.T) {
 	expectRecords := generateRecords(4)
 	values := make([][]byte, 4)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key, values, expectRecords))
@@ -400,7 +400,7 @@ func TestSet_SUnion(t *testing.T) {
 
 	values := make([][]byte, 10)
 	for i := range expectRecords {
-		values[i] = expectRecords[i].V
+		values[i] = expectRecords[i].Value
 	}
 
 	require.NoError(t, set.SAdd(key1, values[:5], expectRecords[:5]))

--- a/tx_list.go
+++ b/tx_list.go
@@ -67,7 +67,7 @@ func (tx *Tx) RPeek(bucket string, key []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	v, err := tx.db.getValueByRecord(item.r)
+	v, err := tx.db.getValueByRecord(item.record)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (tx *Tx) LPeek(bucket string, key []byte) (item []byte, err error) {
 		return nil, err
 	}
 
-	v, err := tx.db.getValueByRecord(r.r)
+	v, err := tx.db.getValueByRecord(r.record)
 	if err != nil {
 		return nil, err
 	}

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -443,10 +443,10 @@ func TestTx_ListEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 
 		listIdx := db.Index.list.getWithDefault(1)
 		item, ok := listIdx.Items[string(key)].PopMin()
-		r := item.r
+		r := item.record
 		require.True(t, ok)
-		require.NotNil(t, r.V)
-		require.Equal(t, []byte("a"), r.V)
+		require.NotNil(t, r.Value)
+		require.Equal(t, []byte("a"), r.Value)
 	})
 }
 
@@ -470,9 +470,9 @@ func TestTx_ListEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 
 		listIdx := db.Index.list.getWithDefault(1)
 		item, ok := listIdx.Items[string(key)].PopMin()
-		r := item.r
+		r := item.record
 		require.True(t, ok)
-		require.Nil(t, r.V)
+		require.Nil(t, r.Value)
 
 		val, err := db.getValueByRecord(r)
 		require.NoError(t, err)

--- a/tx_test.go
+++ b/tx_test.go
@@ -161,23 +161,6 @@ func TestTx_CommittedStatus(t *testing.T) {
 			err = tx.Commit()
 			assert.NoError(t, err)
 		}
-
-		{ // check data
-
-			tx, err := db.Begin(false)
-			assert.NoError(t, err)
-
-			entry1, err := tx.Get(bucket, []byte("key1"))
-			assert.NoError(t, err)
-			assert.Equalf(t, UnCommitted, entry1.Meta.Status, "not the last entry should be uncommitted")
-
-			entry2, err := tx.Get(bucket, []byte("key2"))
-			assert.NoError(t, err)
-			assert.Equalf(t, Committed, entry2.Meta.Status, "the last entry should be committed")
-
-			err = tx.Commit()
-			assert.NoError(t, err)
-		}
 	})
 }
 
@@ -200,24 +183,6 @@ func TestTx_PutWithTimestamp(t *testing.T) {
 				assert.NoError(t, err)
 
 			}
-			err = tx.Commit()
-			assert.NoError(t, err)
-		}
-
-		{ // check timestamp
-			tx, err := db.Begin(false)
-			assert.NoError(t, err)
-
-			for i, timestamp := range timestamps {
-				key := []byte("key_" + fmt.Sprintf("%03d", i))
-
-				entry, err := tx.Get(bucket, key)
-				assert.NoError(t, err)
-
-				assert.Equalf(t, entry.Meta.Timestamp, timestamp, "entry has wrong timestamp")
-
-			}
-
 			err = tx.Commit()
 			assert.NoError(t, err)
 		}

--- a/tx_zset_test.go
+++ b/tx_zset_test.go
@@ -358,8 +358,8 @@ func TestTx_ZSetEntryIdxMode_HintKeyValAndRAMIdxMode(t *testing.T) {
 		hash, _ := getFnv32(value)
 		node := zset.dict[hash]
 
-		require.NotNil(t, node.record.V)
-		require.Equal(t, value, node.record.V)
+		require.NotNil(t, node.record.Value)
+		require.Equal(t, value, node.record.Value)
 	})
 }
 
@@ -386,8 +386,7 @@ func TestTx_ZSetEntryIdxMode_HintKeyAndRAMIdxMode(t *testing.T) {
 		hash, _ := getFnv32(value)
 		node := zset.dict[hash]
 
-		require.NotNil(t, node.record.H)
-		require.Nil(t, node.record.V)
+		require.Nil(t, node.record.Value)
 
 		v, err := db.getValueByRecord(node.record)
 		require.NoError(t, err)


### PR DESCRIPTION
Previously, Record was used as a memory index item, which had many unnecessary fields placed in memory #505 . This time, all of them are removed. One record can save 22 bytes of memory usage!

At the same time, the interface of the BTree index type is modified. It no longer returns Entry, but directly returns Value of byte array type.

It can increase the ease of use. If users need to use other fields in Entry, we can provide an interface.