### PR TITLE
fix: build index for bucket after creation

### DIFF
--- a/db.go
+++ b/db.go
@@ -702,7 +702,8 @@ func (db *DB) buildSortedSetIdx(record *Record, entry *Entry) error {
 		_, _, err = ss.ZPopMin(string(key))
 	}
 
-	if err != nil {
+	// We don't need to panic if sorted set is not found.
+	if err != nil && !errors.Is(err, ErrSortedSetNotFound) {
 		return fmt.Errorf("when build sortedSetIdx err: %s", err)
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -206,7 +206,7 @@ func TestDB_DeleteANonExistKey(t *testing.T) {
 		testBucket := "test_bucket"
 		txCreateBucket(t, db, DataStructureBTree, testBucket, nil)
 
-		txDel(t, db, testBucket, GetTestBytes(0), ErrNotFoundBucket)
+		txDel(t, db, testBucket, GetTestBytes(0), ErrKeyNotFound)
 		txPut(t, db, testBucket, GetTestBytes(1), GetRandomBytes(24), Persistent, nil, nil)
 		txDel(t, db, testBucket, GetTestBytes(0), ErrKeyNotFound)
 	})
@@ -676,7 +676,7 @@ func TestDB_GetKeyNotFound(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		bucket := "bucket"
 		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-		txGet(t, db, bucket, GetTestBytes(0), nil, ErrBucketNotFound)
+		txGet(t, db, bucket, GetTestBytes(0), nil, ErrKeyNotFound)
 		txPut(t, db, bucket, GetTestBytes(1), GetRandomBytes(24), Persistent, nil, nil)
 		txGet(t, db, bucket, GetTestBytes(0), nil, ErrKeyNotFound)
 	})

--- a/tx.go
+++ b/tx.go
@@ -284,8 +284,6 @@ func (tx *Tx) Commit() (err error) {
 		return err
 	}
 
-	// This can be combined with DeleteBucketInIndex. For now I'll use seperate
-	// method.
 	if err := tx.buildBucketInIndex(); err != nil {
 		return err
 	}

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -320,10 +320,10 @@ func TestTx_LSize(t *testing.T) {
 func TestTx_LRemByIndex(t *testing.T) {
 	bucket := "bucket"
 
-	// Calling LRemByIndex on a non-existent list
+	// Calling LRemByIndex on a newly created empty list
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		txCreateBucket(t, db, DataStructureList, bucket, nil)
-		txLRemByIndex(t, db, bucket, GetTestBytes(0), ErrListNotFound)
+		txLRemByIndex(t, db, bucket, GetTestBytes(0), nil)
 	})
 
 	// Calling LRemByIndex with len(indexes) == 0

--- a/tx_test.go
+++ b/tx_test.go
@@ -188,3 +188,33 @@ func TestTx_PutWithTimestamp(t *testing.T) {
 		}
 	})
 }
+
+func TestTx_Commit(t *testing.T) {
+	t.Run("build_bucket_indexes_after_commit", func(t *testing.T) {
+		withDefaultDB(t, func(t *testing.T, db *DB) {
+			bucket := "bucket1"
+
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+			assert.Equal(t, 1, db.Index.bTree.defaultOp.getIdxLen())
+			txDeleteBucket(t, db, DataStructureBTree, bucket, nil)
+			assert.Equal(t, 0, db.Index.bTree.defaultOp.getIdxLen())
+
+			txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+			assert.Equal(t, 1, db.Index.sortedSet.defaultOp.getIdxLen())
+			txDeleteBucket(t, db, DataStructureSortedSet, bucket, nil)
+			assert.Equal(t, 0, db.Index.sortedSet.defaultOp.getIdxLen())
+
+			txCreateBucket(t, db, DataStructureList, bucket, nil)
+			assert.Equal(t, 1, db.Index.list.defaultOp.getIdxLen())
+			txDeleteBucket(t, db, DataStructureList, bucket, nil)
+			assert.Equal(t, 0, db.Index.list.defaultOp.getIdxLen())
+
+			txCreateBucket(t, db, DataStructureSet, bucket, nil)
+			assert.Equal(t, 1, db.Index.set.defaultOp.getIdxLen())
+			txDeleteBucket(t, db, DataStructureSet, bucket, nil)
+			assert.Equal(t, 0, db.Index.set.defaultOp.getIdxLen())
+
+		})
+	})
+
+}

--- a/tx_zset_test.go
+++ b/tx_zset_test.go
@@ -15,9 +15,10 @@
 package nutsdb
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var tx *Tx
@@ -153,8 +154,8 @@ func TestTx_ZPop(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 
-		txZPop(t, db, bucket, key, true, nil, 0, ErrBucket)
-		txZPop(t, db, bucket, key, false, nil, 0, ErrBucket)
+		txZPop(t, db, bucket, key, true, nil, 0, ErrSortedSetNotFound)
+		txZPop(t, db, bucket, key, false, nil, 0, ErrSortedSetNotFound)
 
 		txZAdd(t, db, bucket, key, GetTestBytes(0), float64(0), nil, nil)
 		txZRem(t, db, bucket, key, GetTestBytes(0), nil)
@@ -241,7 +242,7 @@ func TestTx_ZRemRangeByRank(t *testing.T) {
 
 		err := db.Update(func(tx *Tx) error {
 			err := tx.ZRemRangeByRank(bucket, key, 1, 10)
-			assert.Error(t, err)
+			assert.NoError(t, err)
 			return nil
 		})
 		assert.NoError(t, err)
@@ -312,8 +313,8 @@ func TestTx_ZRank(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
 
-		txZRank(t, db, bucket, key, GetTestBytes(0), true, 0, ErrBucket)
-		txZRank(t, db, bucket, key, GetTestBytes(0), false, 0, ErrBucket)
+		txZRank(t, db, bucket, key, GetTestBytes(0), true, 0, ErrSortedSetNotFound)
+		txZRank(t, db, bucket, key, GetTestBytes(0), false, 0, ErrSortedSetNotFound)
 
 		for i := 0; i < 10; i++ {
 			txZAdd(t, db, bucket, key, GetTestBytes(i), float64(i), nil, nil)


### PR DESCRIPTION
Hi Team,

This fixes #526 .  I'm aware that We cannot use the bucket created in the same transaction Tx. But this is about the visibility of the bucket in another transaction Tx after bucket creation was successful. 

Please see the example I've provided in #526 

Thanks,
Sankeerthan