### PR TITLE
fix: should be ignore when error bucket not exist

### DIFF
--- a/db.go
+++ b/db.go
@@ -442,7 +442,7 @@ func (db *DB) parseDataFiles(dataFileIds []int) (err error) {
 			// its because it already deleted in the feature WAL log.
 			// so we can just ignore here.
 			bucketId := entry.Meta.BucketId
-			if b, err := db.bm.GetBucketById(bucketId); b == nil && err == nil {
+			if b, err := db.bm.GetBucketById(bucketId); b == nil && errors.Is(err, ErrBucketNotExist) {
 				continue
 			}
 

--- a/db.go
+++ b/db.go
@@ -442,7 +442,7 @@ func (db *DB) parseDataFiles(dataFileIds []int) (err error) {
 			// its because it already deleted in the feature WAL log.
 			// so we can just ignore here.
 			bucketId := entry.Meta.BucketId
-			if b, err := db.bm.GetBucketById(bucketId); b == nil && errors.Is(err, ErrBucketNotExist) {
+			if _, err := db.bm.GetBucketById(bucketId); errors.Is(err, ErrBucketNotExist) {
 				continue
 			}
 

--- a/db_test.go
+++ b/db_test.go
@@ -192,8 +192,8 @@ func TestDB_ReopenWithDelete(t *testing.T) {
 
 	bucket := "bucket"
 	txCreateBucket(t, db, DataStructureList, bucket, nil)
-	txPush(t, db, bucket, []byte("try"), []byte("1"), true, nil, nil)
-	txPush(t, db, bucket, []byte("try"), []byte("2"), true, nil, nil)
+	txPush(t, db, bucket, GetTestBytes(5), GetTestBytes(0), true, nil, nil)
+	txPush(t, db, bucket, GetTestBytes(5), GetTestBytes(1), true, nil, nil)
 	txDeleteBucket(t, db, DataStructureList, bucket, nil)
 
 	if !db.IsClose() {


### PR DESCRIPTION
Hi Team,

This fixes [#532](https://github.com/nutsdb/nutsdb/issues/532). 

Please see the example I've provided in https://github.com/nutsdb/nutsdb/issues/532

Kind Regards,

Yudha