### PR TITLE
Implements of MSet, MGet, GetRange and Append

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1548,3 +1548,41 @@ func txPersist(t *testing.T, db *DB, bucket string, key []byte, expectedErr erro
 	})
 	require.NoError(t, err)
 }
+
+func txMSet(t *testing.T, db *DB, bucket string, args [][]byte, ttl uint32, expectErr error, finalExpectErr error) {
+	err := db.Update(func(tx *Tx) error {
+		err := tx.MSet(bucket, ttl, args...)
+		assertErr(t, err, expectErr)
+		return nil
+	})
+	assertErr(t, err, finalExpectErr)
+}
+
+func txMGet(t *testing.T, db *DB, bucket string, keys [][]byte, expectValues [][]byte, expectErr error, finalExpectErr error) {
+	err := db.View(func(tx *Tx) error {
+		values, err := tx.MGet(bucket, keys...)
+		assertErr(t, err, expectErr)
+		require.EqualValues(t, expectValues, values)
+		return nil
+	})
+	assertErr(t, err, finalExpectErr)
+}
+
+func txAppend(t *testing.T, db *DB, bucket string, key, appendage []byte, expectErr error, expectFinalErr error) {
+	err := db.Update(func(tx *Tx) error {
+		err := tx.Append(bucket, key, appendage)
+		assertErr(t, err, expectErr)
+		return nil
+	})
+	assertErr(t, err, expectFinalErr)
+}
+
+func txGetRange(t *testing.T, db *DB, bucket string, key []byte, start, end int, expectVal []byte, expectErr error, expectFinalErr error) {
+	err := db.View(func(tx *Tx) error {
+		value, err := tx.GetRange(bucket, key, start, end)
+		assertErr(t, err, expectErr)
+		require.EqualValues(t, expectVal, value)
+		return nil
+	})
+	assertErr(t, err, expectFinalErr)
+}

--- a/examples/k-v/append/main.go
+++ b/examples/k-v/append/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"github.com/nutsdb/nutsdb"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var (
+	db     *nutsdb.DB
+	bucket string
+	err    error
+)
+
+func init() {
+	fileDir := "/tmp/nutsdb_example"
+
+	files, _ := ioutil.ReadDir(fileDir)
+	for _, f := range files {
+		name := f.Name()
+		if name != "" {
+			err := os.RemoveAll(fileDir + "/" + name)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+	db, _ = nutsdb.Open(
+		nutsdb.DefaultOptions,
+		nutsdb.WithDir(fileDir),
+		nutsdb.WithSegmentSize(1024*1024), // 1MB
+	)
+	if err != nil {
+		panic(err)
+	}
+	bucket = "bucketForString"
+
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.NewBucket(nutsdb.DataStructureBTree, bucket)
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	// If we use tx.Append on a non-exist key, it will create a pair of K-V and use the appendage as its value.
+	append("non-exist", "something")
+	get("non-exist") // get value: 'something'
+
+	// If we use tx.Append on an exist key, it will append the given appendage to the existed value.
+	put("key", "value")
+	append("key", "more value")
+	get("key") // get value: 'valuemore value'
+}
+
+func get(key string) {
+	if err := db.View(func(tx *nutsdb.Tx) error {
+		value, err := tx.Get(bucket, []byte(key))
+		if err != nil {
+			return err
+		}
+		log.Printf("get value: '%s'", string(value))
+		return nil
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func put(key, value string) {
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.Put(bucket, []byte(key), []byte(value), nutsdb.Persistent)
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func append(key, appendage string) {
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.Append(bucket, []byte(key), []byte(appendage))
+	}); err != nil {
+		log.Println(err)
+	}
+}

--- a/examples/k-v/get_range/main.go
+++ b/examples/k-v/get_range/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"github.com/nutsdb/nutsdb"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var (
+	db     *nutsdb.DB
+	bucket string
+	err    error
+)
+
+func init() {
+	fileDir := "/tmp/nutsdb_example"
+
+	files, _ := ioutil.ReadDir(fileDir)
+	for _, f := range files {
+		name := f.Name()
+		if name != "" {
+			err := os.RemoveAll(fileDir + "/" + name)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+	db, _ = nutsdb.Open(
+		nutsdb.DefaultOptions,
+		nutsdb.WithDir(fileDir),
+		nutsdb.WithSegmentSize(1024*1024), // 1MB
+	)
+	if err != nil {
+		panic(err)
+	}
+	bucket = "bucketForString"
+
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.NewBucket(nutsdb.DataStructureBTree, bucket)
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	// If we use tx.GetRange on a non-exist key, it will throw an error about key not found
+	getRange("non-exist", 0, 0) // key not found
+
+	put("key", "This is a test value")
+	// If we use tx.GetRange with a pair of start and end which start is greater than end, it will throw an error.
+	getRange("key", 5, 3) // start is greater than end
+	// When start < end but start is greater than the size of value, it will return an empty value.
+	getRange("key", 100, 120) // got value: ''
+	// When start is less than the size of value, but end is greater. It will use value[start:] as its return.
+	getRange("key", 10, 100) // got value: 'test value'
+	// When end is less than the size of value. It will use value[start:end+1] as its return. This is same with Redis.
+	getRange("key", 10, 13) // got value: 'test'
+}
+
+func put(key, value string) {
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.Put(bucket, []byte(key), []byte(value), nutsdb.Persistent)
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func getRange(key string, start, end int) {
+	if err := db.View(func(tx *nutsdb.Tx) error {
+		value, err := tx.GetRange(bucket, []byte(key), start, end)
+		if err != nil {
+			return err
+		}
+		log.Printf("got value: '%s'", string(value))
+		return nil
+	}); err != nil {
+		log.Println(err)
+	}
+}

--- a/examples/k-v/multioprations/main.go
+++ b/examples/k-v/multioprations/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"github.com/nutsdb/nutsdb"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var (
+	db     *nutsdb.DB
+	bucket string
+	err    error
+)
+
+func init() {
+	fileDir := "/tmp/nutsdb_example"
+
+	files, _ := ioutil.ReadDir(fileDir)
+	for _, f := range files {
+		name := f.Name()
+		if name != "" {
+			err := os.RemoveAll(fileDir + "/" + name)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+	db, _ = nutsdb.Open(
+		nutsdb.DefaultOptions,
+		nutsdb.WithDir(fileDir),
+		nutsdb.WithSegmentSize(1024*1024), // 1MB
+	)
+	if err != nil {
+		panic(err)
+	}
+	bucket = "bucketForString"
+
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.NewBucket(nutsdb.DataStructureBTree, bucket)
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	// When we use tx.MSet, we must use even number of []byte as its parameters.
+	// When i is an even number, the no.i arg and the no.i+1 arg will be a pair of K-V.
+	// If there're odd number of args, it will throw an error
+	mSet([]byte("1")) //  parameters is used to represent key value pairs and cannot be odd numbers
+
+	// Normally, we use tx.MSet and tx.MGet to do some multiple operations.
+	mSet([]byte("1"), []byte("one"), []byte("2"), []byte("two"))
+	// get value by MGet, the  0  value is: 'one'
+	// get value by MGet, the  1  value is: 'two'
+	mGet([]byte("1"), []byte("2"))
+}
+
+func mGet(key ...[]byte) {
+	if err := db.View(func(tx *nutsdb.Tx) error {
+		values, err := tx.MGet(bucket, key...)
+		if err != nil {
+			return err
+		}
+		for i, value := range values {
+			log.Printf("get value by MGet, the %d value is '%s'", i, string(value))
+		}
+		return nil
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func mSet(args ...[]byte) {
+	if err := db.Update(func(tx *nutsdb.Tx) error {
+		return tx.MSet(bucket, nutsdb.Persistent, args...)
+	}); err != nil {
+		log.Println(err)
+	}
+}

--- a/tx_error.go
+++ b/tx_error.go
@@ -56,4 +56,8 @@ var (
 	ErrValueNotInteger = errors.New("value is not an integer")
 
 	ErrOffsetInvalid = errors.New("offset is invalid")
+
+	ErrKVArgsLenNotEven = errors.New("parameters is used to represent key value pairs and cannot be odd numbers")
+
+	ErrStartGreaterThanEnd = errors.New("start is greater than end")
 )


### PR DESCRIPTION
This PR is related with #517

- Add `tx.MGet` and `tx.MSet`. Use slices as the returned value.
- Add `tx.Append`.
- Add `tx.GetRange`. It will get the part by using a closed interval which composed with 2 `int`

## `tx.MGet` and `tx.MSet`

- If calling them with 0 arg. Them will do nothing and return a `nil`.
- We must use an even number of args to call `tx.MSet`. If `i` is an even number, the `i`th arg and the `i+1`th arg will be a pair of k-v.

## `tx.Append`

- If calling it with a empty appendage, it will do nothing and return a `nil`
- If use this method on a non-exist key, it will create a new value with the given appendage.

## `tx.GetRange`

- Use `start` and `end` to be a closed interval and get the part of value by using it. (This is same with Redis)
- If `start` is greater than `end`, it will throw an error.
- If `start` is greater than the size of value, it will return a `nil`
- If `end` is greater than the size of value, it will return `value[start:]`
- Normally, it will return `value[start:end+1]`

