### PR TITLE
docs(user_guide): fix typos in user_guide docs

### DIFF
--- a/docs/user_guides/data-structure.md
+++ b/docs/user_guides/data-structure.md
@@ -784,7 +784,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        num, err := tx.ZCard(bucket, string(key))
+        num, err := tx.ZCard(bucket, key)
         if err != nil {
             return err
         }
@@ -800,7 +800,7 @@ if err := db.View(
   <summary><b>ZCount</b></summary>
 Returns the number of elements in the sorted set specified by key in a bucket with a score between min and max and opts.
 
-Opts includes the following parameters:
+Opts include the following parameters:
 
 - Limit int // limit the max nodes to return
 - ExcludeStart bool // exclude start value, so it search in interval (start, end] or (start, end)
@@ -811,7 +811,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        num, err := tx.ZCount(bucket, string(key), 0, 1, nil)
+        num, err := tx.ZCount(bucket, key, 0, 1, nil)
         if err != nil {
             return err
         }
@@ -832,7 +832,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        score, err := tx.ZScore(bucket, string(key), []byte("val1"))
+        score, err := tx.ZScore(bucket, key, []byte("val1"))
         if err != nil {
             return err
         }
@@ -853,7 +853,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        nodes, err := tx.ZMembers(bucket, string(key))
+        nodes, err := tx.ZMembers(bucket, key)
         if err != nil {
             return err
         }
@@ -876,7 +876,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        node, err := tx.ZPeekMax(bucket, string(key))
+        node, err := tx.ZPeekMax(bucket, key))
         if err != nil {
             return err
         }
@@ -897,7 +897,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        node, err := tx.ZPeekMin(bucket, string(key))
+        node, err := tx.ZPeekMin(bucket, key)
         if err != nil {
             return err
         }
@@ -918,7 +918,7 @@ if err := db.Update(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        node, err := tx.ZPopMax(bucket, string(key))
+        node, err := tx.ZPopMax(bucket, key)
         if err != nil {
             return err
         }
@@ -939,7 +939,7 @@ if err := db.Update(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        node, err := tx.ZPopMin(bucket, string(key))
+        node, err := tx.ZPopMin(bucket, key)
         if err != nil {
             return err
         }
@@ -987,7 +987,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        nodes, err := tx.ZRangeByRank(bucket, string(key), 1, 3)
+        nodes, err := tx.ZRangeByRank(bucket, key, 1, 3)
         if err != nil {
             return err
         }
@@ -1037,12 +1037,12 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        nodes, err := tx.ZRangeByScore(bucket, string(key), 80, 100, nil)
+        nodes, err := tx.ZRangeByScore(bucket, key, 80, 100, nil)
         if err != nil {
             return err
         }
         for _, node := range nodes {
-            fmt.Println("item:", node.Value, node.Score)
+            fmt.Println("item:", string(node.Value), node.Score)
         }
         return nil
     }); err != nil {
@@ -1061,7 +1061,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val1"))
+        rank, err := tx.ZRank(bucket, key, []byte("val1"))
         if err != nil {
             return err
         }
@@ -1075,7 +1075,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val2"))
+        rank, err := tx.ZRank(bucket, key, []byte("val2"))
         if err != nil {
             return err
         }
@@ -1089,7 +1089,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val3"))
+        rank, err := tx.ZRank(bucket, key, []byte("val3"))
         if err != nil {
             return err
         }
@@ -1111,7 +1111,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val1"))
+        rank, err := tx.ZRank(bucket, key, []byte("val1"))
         if err != nil {
             return err
         }
@@ -1124,7 +1124,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val2"))
+        rank, err := tx.ZRank(bucket, key, []byte("val2"))
         if err != nil {
             return err
         }
@@ -1137,7 +1137,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        rank, err := tx.ZRank(bucket, string(key), []byte("val3"))
+        rank, err := tx.ZRank(bucket, key, []byte("val3"))
         if err != nil {
             return err
         }
@@ -1151,14 +1151,14 @@ if err := db.View(
 
 <details>
   <summary><b>ZRem</b></summary>
-Returns the member with the lowest score in the sorted set specified by key in a bucket.
+Removes the member with the lowest score in the sorted set specified by key in a bucket.
 
 ```go
 if err := db.Update(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        return tx.ZRem(bucket, string(key), []byte("val3"))
+        return tx.ZRem(bucket, key, []byte("val3"))
     }); err != nil {
     log.Fatal(err)
 }
@@ -1167,7 +1167,7 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        nodes, err := tx.ZMembers(bucket, string(key))
+        nodes, err := tx.ZMembers(bucket, key)
         if err != nil {
             return err
         }
@@ -1191,7 +1191,7 @@ if err := db.Update(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        return tx.ZRemRangeByRank(bucket, string(key), 1, 2)
+        return tx.ZRemRangeByRank(bucket, key, 1, 2)
     }); err != nil {
     log.Fatal(err)
 }
@@ -1200,11 +1200,11 @@ if err := db.View(
     func(tx *nutsdb.Tx) error {
         bucket := "myZSet1"
         key := []byte("key1")
-        nodes, err := tx.ZMembers(bucket, string(key))
+        nodes, err := tx.ZMembers(bucket, key)
         if err != nil {
             return err
         }
-        fmt.Println("after ZRemRangeByRank, ZMembers nodes is 0")
+        fmt.Println("after ZRemRangeByRank, ZMembers nodes is", len(nodes))
         for node := range nodes {
             fmt.Println("item:", node.Score, string(node.Value))
         }

--- a/docs/user_guides/use-buckets.md
+++ b/docs/user_guides/use-buckets.md
@@ -8,14 +8,14 @@ val := []byte("val001")
 
 bucket001 := "bucket001"
 
-if err := db.Update(func(tx *Tx) error {
+if err := db.Update(func(tx *nutsdb.Tx) error {
     // you should call Bucket with data structure and the name of bucket first
-    return tx.NewBucket(DataStructureBTree, bucket001)
+    return tx.NewBucket(nutsdb.DataStructureBTree, bucket001)
 }); err != nil {
     log.Fatal(err)
 }
 
-if err := db.Update(func(tx *Tx) error {
+if err := db.Update(func(tx *nutsdb.Tx) error {
     return tx.Put(bucket001, key, val, 0)
 }); err != nil {
     log.Fatal(err)
@@ -41,13 +41,13 @@ The current version of `ds` (represents the data structure):
 
 - DataStructureSet
 - DataStructureSortedSet
-- DataStructureBPTree
+- DataStructureBTree
 - DataStructureList
 
 ```go
 if err := db.View(
     func(tx *nutsdb.Tx) error {
-        return tx.IterateBuckets(nutsdb.DataStructureBPTree, "*", func(bucket string) bool {
+        return tx.IterateBuckets(nutsdb.DataStructureBTree, "*", func(bucket string) bool {
             fmt.Println("bucket: ", bucket)
             // true: continue, false: break
             return true
@@ -70,15 +70,14 @@ The current version of `ds` (represents the data structure)：
 
 - DataStructureSet
 - DataStructureSortedSet
-- DataStructureBPTree
+- DataStructureBTree
 - DataStructureList
 
 ```go
 if err := db.Update(
     func(tx *nutsdb.Tx) error {
-        return tx.DeleteBucket(nutsdb.DataStructureBPTree, bucket)
+        return tx.DeleteBucket(nutsdb.DataStructureBTree, bucket)
     }); err != nil {
     log.Fatal(err)
 }
-   
 ```


### PR DESCRIPTION
### Description

-  Fix typos in [use-buckets.md](https://github.com/nutsdb/nutsdb/blob/master/docs/user_guides/use-buckets.md)
   -  Add package name prefix to the type
   - `DataStructureBPTree -> DataStructureBTree`
-  Fix typos in section `Sorted Set` of [data-structure.md](https://github.com/nutsdb/nutsdb/blob/master/docs/user_guides/data-structure.md)
   - The type of `key`  parameter in `tx.Z*` functions should be `[]byte`:  `string(key) -> key`
   - The example of `ZRangeByScore`: Print `node.Value` as `string ` instead of `[]byte` 
   - The example of `ZRemRangeByRank`: Print the length of `nodes` instead of “0”
   - Description of `ZRem`: `Returns ... -> Removes ...`
   - Description of `ZCount`: `Opts includes ... -> Opts include ...`

