### PR TITLE
fix panic when writing the same key multiple times in the same transaction

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -228,9 +228,8 @@ func (tx *Tx) Commit() (err error) {
 	var records []*Record
 
 	pendingWriteList := tx.pendingWrites.toList()
-	writesLen := tx.pendingWrites.size
-	lastIndex := writesLen - 1
-	for i := 0; i < writesLen; i++ {
+	lastIndex := len(pendingWriteList) - 1
+	for i := 0; i < len(pendingWriteList); i++ {
 		entry := pendingWriteList[i]
 		entrySize := entry.Size()
 		if entrySize > tx.db.opt.SegmentSize {


### PR DESCRIPTION
We have some code which can end up writing the same key multiple times in the same transaction. In this case, when entries are added to a `pendingList`, the size is incremented but the number of total entries doesn't change (since it's stored in a map). This results in `nil` values when it's converted to a native go slice, causing a crash when committing the transaction.

The stack trace when crashing is similar to #580 