### PR TITLE
Tx: var err is not assigned at all (fixup)

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -765,10 +765,10 @@ func (tx *Tx) buildBucketInIndex() error {
 
 func (tx *Tx) getChangeCountInEntriesChanges() int64 {
 	var res int64
-	var err error
+
 	for _, entriesInDS := range tx.pendingWrites.entriesInBTree {
 		for _, entry := range entriesInDS {
-			curRecordCnt, _ := tx.getEntryNewAddRecordCount(entry)
+			curRecordCnt, err := tx.getEntryNewAddRecordCount(entry)
 			if err != nil {
 				return res
 			}
@@ -778,7 +778,7 @@ func (tx *Tx) getChangeCountInEntriesChanges() int64 {
 	for _, entriesInDS := range tx.pendingWrites.entries {
 		for _, entries := range entriesInDS {
 			for _, entry := range entries {
-				curRecordCnt, _ := tx.getEntryNewAddRecordCount(entry)
+				curRecordCnt, err := tx.getEntryNewAddRecordCount(entry)
 				if err != nil {
 					return res
 				}


### PR DESCRIPTION
The buggy code declared `var err`, but never assigned to it. so the
`if err != nil` will always be false, and the error case was missed.

Signed-off-by: Park Zhou <ideapark@139.com>
