### PR TITLE
fix: merge error issue 在window下 Merge报错 #578

### DIFF
--- a/bucket_manager.go
+++ b/bucket_manager.go
@@ -3,6 +3,8 @@ package nutsdb
 import (
 	"errors"
 	"os"
+
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 )
 
 var ErrBucketNotExist = errors.New("bucket not exist")
@@ -26,18 +28,19 @@ type BucketManager struct {
 	Gen *IDGenerator
 }
 
-func NewBucketManager(dir string) (*BucketManager, error) {
+func NewBucketManager(dir nutspath.Path) (*BucketManager, error) {
 	bm := &BucketManager{
 		BucketInfoMapper: map[BucketId]*Bucket{},
 		BucketIDMarker:   map[BucketName]map[Ds]BucketId{},
 	}
-	bucketFilePath := dir + "/" + BucketStoreFileName
-	_, err := os.Stat(bucketFilePath)
+
+	bucketFilePath := dir.Join(BucketStoreFileName)
+	_, err := os.Stat(bucketFilePath.String())
 	mode := os.O_RDWR
 	if err != nil {
 		mode |= os.O_CREATE
 	}
-	fd, err := os.OpenFile(bucketFilePath, mode, os.ModePerm)
+	fd, err := os.OpenFile(bucketFilePath.String(), mode, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}
@@ -126,4 +129,8 @@ func (bm *BucketManager) GetBucketID(ds Ds, name BucketName) (BucketId, error) {
 	} else {
 		return bucket.Id, nil
 	}
+}
+
+func (bm *BucketManager) close() error {
+	return bm.fd.Close()
 }

--- a/bucket_manager_test.go
+++ b/bucket_manager_test.go
@@ -1,8 +1,9 @@
 package nutsdb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBucketManager_NewBucketAndDeleteBucket(t *testing.T) {
@@ -15,10 +16,11 @@ func TestBucketManager_NewBucketAndDeleteBucket(t *testing.T) {
 		txNewBucket(t, db, bucket2, DataStructureBTree, nil, nil)
 		exist = db.bm.ExistBucket(DataStructureBTree, bucket2)
 		assert.Equal(t, true, exist)
+
+		db.Close()
 	})
 
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
-		txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)
 		exist := db.bm.ExistBucket(DataStructureBTree, bucket1)
 		assert.Equal(t, true, exist)
 		txDeleteBucketFunc(t, db, bucket1, DataStructureBTree, nil, nil)
@@ -44,7 +46,14 @@ func TestBucketManager_Recovery(t *testing.T) {
 	const bucket1 = "bucket_1"
 	const bucket2 = "bucket_2"
 	db, err := Open(DefaultOptions, WithDir(dir))
-	defer removeDir(dir)
+	defer func() {
+		if !db.IsClose() {
+			db.Close()
+		}
+
+		removeDir(dir)
+	}()
+
 	assert.NotNil(t, db)
 	assert.Nil(t, err)
 	txNewBucket(t, db, bucket1, DataStructureBTree, nil, nil)

--- a/datafile.go
+++ b/datafile.go
@@ -16,6 +16,8 @@ package nutsdb
 
 import (
 	"errors"
+
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 )
 
 var (
@@ -35,7 +37,7 @@ const (
 
 // DataFile records about data file information.
 type DataFile struct {
-	path       string
+	path       nutspath.Path
 	fileID     int64
 	writeOff   int64
 	ActualSize int64
@@ -43,7 +45,7 @@ type DataFile struct {
 }
 
 // NewDataFile will return a new DataFile Object.
-func NewDataFile(path string, rwManager RWManager) *DataFile {
+func NewDataFile(path nutspath.Path, rwManager RWManager) *DataFile {
 	dataFile := &DataFile{
 		path:      path,
 		rwManager: rwManager,

--- a/datafile_test.go
+++ b/datafile_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +41,7 @@ func init() {
 func TestDataFile_Err(t *testing.T) {
 	fm := newFileManager(MMap, 1024, 0.5, 256*MB)
 	defer fm.close()
-	_, err := fm.getDataFile(filePath, -1)
+	_, err := fm.getDataFile(nutspath.New(filePath), -1)
 	defer func() {
 		os.Remove(filePath)
 	}()
@@ -51,7 +52,7 @@ func TestDataFile_Err(t *testing.T) {
 func TestDataFile1(t *testing.T) {
 	fm := newFileManager(MMap, 1024, 0.5, 256*MB)
 	defer fm.close()
-	df, err := fm.getDataFile(filePath, 1024)
+	df, err := fm.getDataFile(nutspath.New(filePath), 1024)
 	defer os.Remove(filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -82,7 +83,7 @@ func TestDataFile2(t *testing.T) {
 	fm := newFileManager(FileIO, 1024, 0.5, 256*MB)
 
 	filePath2 := "/tmp/foo2"
-	df, err := fm.getDataFile(filePath2, 64)
+	df, err := fm.getDataFile(nutspath.New(filePath2), 64)
 	assert.Nil(t, err)
 	defer os.Remove(filePath2)
 	headerSize := entry.Meta.Size()
@@ -100,7 +101,7 @@ func TestDataFile2(t *testing.T) {
 
 	filePath3 := "/tmp/foo3"
 
-	df2, err := fm.getDataFile(filePath3, 64)
+	df2, err := fm.getDataFile(nutspath.New(filePath3), 64)
 	defer os.Remove(filePath3)
 	assert.Nil(t, err)
 
@@ -125,7 +126,7 @@ func TestDataFile2(t *testing.T) {
 func TestDataFile_ReadRecord(t *testing.T) {
 	fm := newFileManager(FileIO, 1024, 0.5, 256*MB)
 	filePath4 := "/tmp/foo4"
-	df, err := fm.getDataFile(filePath4, 1024)
+	df, err := fm.getDataFile(nutspath.New(filePath4), 1024)
 	defer func() {
 		err = df.Release()
 		assert.Nil(t, err)
@@ -153,7 +154,7 @@ func TestDataFile_Err_Path(t *testing.T) {
 	fm := newFileManager(FileIO, 1024, 0.5, 256*MB)
 	defer fm.close()
 	filePath5 := ":/tmp/foo5"
-	df, err := fm.getDataFile(filePath5, entry.Size())
+	df, err := fm.getDataFile(nutspath.New(filePath5), entry.Size())
 	if err == nil && df != nil {
 		t.Error("err TestDataFile_All open")
 	}
@@ -163,7 +164,7 @@ func TestDataFile_Crc_Err(t *testing.T) {
 	fm := newFileManager(FileIO, 1024, 0.5, 256*MB)
 	filePath4 := "/tmp/foo6"
 
-	df, err := fm.getDataFile(filePath4, entry.Size())
+	df, err := fm.getDataFile(nutspath.New(filePath4), entry.Size())
 	assert.Nil(t, err)
 	assert.NotNil(t, df)
 	defer func() {
@@ -192,7 +193,7 @@ func TestDataFile_Crc_Err(t *testing.T) {
 func TestFileManager1(t *testing.T) {
 	fm := newFileManager(FileIO, 1024, 0.5, 256*MB)
 	filePath4 := "/tmp/foo6"
-	df, err := fm.getDataFile(filePath4, entry.Size())
+	df, err := fm.getDataFile(nutspath.New(filePath4), entry.Size())
 	assert.Nil(t, err)
 	defer func() {
 		err = df.Release()

--- a/file_manager.go
+++ b/file_manager.go
@@ -1,6 +1,7 @@
 package nutsdb
 
 import (
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 	"github.com/xujiajun/mmap-go"
 )
 
@@ -22,7 +23,7 @@ func newFileManager(rwMode RWMode, maxFdNums int, cleanThreshold float64, segmen
 }
 
 // getDataFile will return a DataFile Object
-func (fm *fileManager) getDataFile(path string, capacity int64) (datafile *DataFile, err error) {
+func (fm *fileManager) getDataFile(path nutspath.Path, capacity int64) (datafile *DataFile, err error) {
 	if capacity <= 0 {
 		return nil, ErrCapacity
 	}
@@ -47,7 +48,7 @@ func (fm *fileManager) getDataFile(path string, capacity int64) (datafile *DataF
 }
 
 // getFileRWManager will return a FileIORWManager Object
-func (fm *fileManager) getFileRWManager(path string, capacity int64, segmentSize int64) (*FileIORWManager, error) {
+func (fm *fileManager) getFileRWManager(path nutspath.Path, capacity int64, segmentSize int64) (*FileIORWManager, error) {
 	fd, err := fm.fdm.getFd(path)
 	if err != nil {
 		return nil, err
@@ -61,7 +62,7 @@ func (fm *fileManager) getFileRWManager(path string, capacity int64, segmentSize
 }
 
 // getMMapRWManager will return a MMapRWManager Object
-func (fm *fileManager) getMMapRWManager(path string, capacity int64, segmentSize int64) (*MMapRWManager, error) {
+func (fm *fileManager) getMMapRWManager(path nutspath.Path, capacity int64, segmentSize int64) (*MMapRWManager, error) {
 	fd, err := fm.fdm.getFd(path)
 	if err != nil {
 		return nil, err

--- a/internal/nutspath/nutspath.go
+++ b/internal/nutspath/nutspath.go
@@ -1,0 +1,27 @@
+package nutspath
+
+import "path/filepath"
+
+type Path string
+
+func getPath(path string, operations ...func(string) string) Path {
+	for _, op := range operations {
+		path = op(path)
+	}
+
+	return Path(filepath.Clean(path))
+}
+
+func New(path string) Path {
+	return getPath(path)
+}
+
+func (p Path) String() string {
+	return string(p)
+}
+
+func (p Path) Join(elem ...string) Path {
+	return getPath(p.String(), func(s string) string {
+		return filepath.Join(append([]string{s}, elem...)...)
+	})
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -87,7 +87,7 @@ func TestDB_MergeForString(t *testing.T) {
 		}
 
 		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+		removeDir(opts.Dir.String())
 	}
 }
 
@@ -178,7 +178,7 @@ func TestDB_MergeForSet(t *testing.T) {
 			txSIsMember(t, db, bucket, key, v, true)
 		}
 		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+		removeDir(opts.Dir.String())
 	}
 }
 
@@ -283,7 +283,7 @@ func TestDB_MergeForZSet(t *testing.T) {
 		}
 
 		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+		removeDir(opts.Dir.String())
 	}
 }
 
@@ -362,6 +362,6 @@ func TestDB_MergeForList(t *testing.T) {
 		}
 
 		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+		removeDir(opts.Dir.String())
 	}
 }

--- a/options.go
+++ b/options.go
@@ -14,7 +14,11 @@
 
 package nutsdb
 
-import "time"
+import (
+	"time"
+
+	"github.com/nutsdb/nutsdb/internal/nutspath"
+)
 
 // EntryIdxMode represents entry index mode.
 type EntryIdxMode int
@@ -54,7 +58,7 @@ type LessFunc func(l, r string) bool
 // Options records params for creating DB object.
 type Options struct {
 	// Dir represents Open the database located in which dir.
-	Dir string
+	Dir nutspath.Path
 
 	// EntryIdxMode represents using which mode to index the entries.
 	EntryIdxMode EntryIdxMode
@@ -139,17 +143,17 @@ var defaultSegmentSize int64 = 256 * MB
 // DefaultOptions represents the default options.
 var DefaultOptions = func() Options {
 	return Options{
-		EntryIdxMode:      HintKeyValAndRAMIdxMode,
-		SegmentSize:       defaultSegmentSize,
-		NodeNum:           1,
-		RWMode:            FileIO,
-		SyncEnable:        true,
-		CommitBufferSize:  4 * MB,
-		MergeInterval:     2 * time.Hour,
-		MaxBatchSize:      (15 * defaultSegmentSize / 4) / 100,
-		MaxBatchCount:     (15 * defaultSegmentSize / 4) / 100 / 100,
+		EntryIdxMode:              HintKeyValAndRAMIdxMode,
+		SegmentSize:               defaultSegmentSize,
+		NodeNum:                   1,
+		RWMode:                    FileIO,
+		SyncEnable:                true,
+		CommitBufferSize:          4 * MB,
+		MergeInterval:             2 * time.Hour,
+		MaxBatchSize:              (15 * defaultSegmentSize / 4) / 100,
+		MaxBatchCount:             (15 * defaultSegmentSize / 4) / 100 / 100,
 		HintKeyAndRAMIdxCacheSize: 0,
-		ExpiredDeleteType: TimeWheel,
+		ExpiredDeleteType:         TimeWheel,
 	}
 }()
 
@@ -157,7 +161,7 @@ type Option func(*Options)
 
 func WithDir(dir string) Option {
 	return func(opt *Options) {
-		opt.Dir = dir
+		opt.Dir = nutspath.New(dir)
 	}
 }
 
@@ -186,9 +190,9 @@ func WithMaxBatchCount(count int64) Option {
 }
 
 func WithHintKeyAndRAMIdxCacheSize(size int) Option {
-    return func(opt *Options) {
-        opt.HintKeyAndRAMIdxCacheSize = size
-    }
+	return func(opt *Options) {
+		opt.HintKeyAndRAMIdxCacheSize = size
+	}
 }
 
 func WithMaxBatchSize(size int64) Option {

--- a/recovery_reader.go
+++ b/recovery_reader.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"io"
 	"os"
+
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 )
 
 // fileRecovery use bufio.Reader to read entry
@@ -13,8 +15,8 @@ type fileRecovery struct {
 	size   int64
 }
 
-func newFileRecovery(path string, bufSize int) (fr *fileRecovery, err error) {
-	fd, err := os.OpenFile(path, os.O_RDWR, os.ModePerm)
+func newFileRecovery(path nutspath.Path, bufSize int) (fr *fileRecovery, err error) {
+	fd, err := os.OpenFile(path.String(), os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}

--- a/recovery_reader_test.go
+++ b/recovery_reader_test.go
@@ -1,16 +1,18 @@
 package nutsdb
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/nutsdb/nutsdb/internal/nutspath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_readEntry(t *testing.T) {
-	path := "/tmp/test_read_entry"
+	path := nutspath.New("/tmp/test_read_entry")
 
-	fd, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_RDWR, os.ModePerm)
+	fd, err := os.OpenFile(path.String(), os.O_TRUNC|os.O_CREATE|os.O_RDWR, os.ModePerm)
 	require.NoError(t, err)
 	meta := NewMetaData().WithKeySize(uint32(len("key"))).
 		WithValueSize(uint32(len("val"))).WithTimeStamp(1547707905).
@@ -35,7 +37,7 @@ func Test_readEntry(t *testing.T) {
 }
 
 func Test_fileRecovery_readBucket(t *testing.T) {
-	filePath := "bucket_test_data"
+	filePath := nutspath.New("bucket_test_data")
 	bucket := &Bucket{
 		Meta: &BucketMeta{
 			Op: BucketInsertOperation,
@@ -46,11 +48,11 @@ func Test_fileRecovery_readBucket(t *testing.T) {
 	}
 	bytes := bucket.Encode()
 
-	fd, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	fd, err := os.OpenFile(filePath.String(), os.O_RDWR|os.O_CREATE, os.ModePerm)
 	defer func() {
 		err = fd.Close()
 		assert.Nil(t, err)
-		err = os.Remove(filePath)
+		err = os.Remove(filePath.String())
 		assert.Nil(t, nil)
 	}()
 	assert.Nil(t, err)

--- a/rwmanager_fileio_test.go
+++ b/rwmanager_fileio_test.go
@@ -3,13 +3,13 @@ package nutsdb
 import (
 	"testing"
 
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRWManager_FileIO_All(t *testing.T) {
-
-	filePath := "/tmp/foo_rw_fileio"
+	filePath := nutspath.New("/tmp/foo_rw_fileio")
 	maxFdNums := 20
 	cleanThreshold := 0.5
 	var fdm *fdManager

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -18,13 +18,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 	"github.com/stretchr/testify/require"
 
 	"github.com/xujiajun/mmap-go"
 )
 
 func TestRWManager_MMap_Release(t *testing.T) {
-	filePath := "/tmp/foo_rw_MMap"
+	filePath := nutspath.New("/tmp/foo_rw_MMap")
 	fdm := newFileManager(MMap, 1024, 0.5, 256*MB)
 	rwmanager, err := fdm.getMMapRWManager(filePath, 1024, 256*MB)
 	if err != nil {
@@ -57,7 +58,7 @@ func (rwmanager *MMapRWManager) IsActive() bool {
 }
 
 func TestRWManager_MMap_WriteAt(t *testing.T) {
-	filePath := "/tmp/foo_rw_filemmap"
+	filePath := nutspath.New("/tmp/foo_rw_filemmap")
 	maxFdNums := 1024
 	cleanThreshold := 0.5
 	var fdm = newFdm(maxFdNums, cleanThreshold)
@@ -90,7 +91,7 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 }
 
 func TestRWManager_MMap_Sync(t *testing.T) {
-	filePath := "/tmp/foo_rw_filemmap"
+	filePath := nutspath.Path("/tmp/foo_rw_filemmap")
 	maxFdNums := 1024
 	cleanThreshold := 0.5
 	var fdm = newFdm(maxFdNums, cleanThreshold)
@@ -115,13 +116,13 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 	m[1] = 'z'
 	err = mmManager.Sync()
 	require.NoError(t, err)
-	fileContents, err := os.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath.String())
 	require.NoError(t, err)
 	require.Equal(t, fileContents, []byte(m[:]))
 }
 
 func TestRWManager_MMap_Close(t *testing.T) {
-	filePath := "/tmp/foo_rw_filemmap"
+	filePath := nutspath.New("/tmp/foo_rw_filemmap")
 	maxFdNums := 1024
 	cleanThreshold := 0.5
 	var fdm = newFdm(maxFdNums, cleanThreshold)

--- a/rwmanger_fileio.go
+++ b/rwmanger_fileio.go
@@ -15,13 +15,14 @@
 package nutsdb
 
 import (
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 	"os"
 )
 
 // FileIORWManager represents the RWManager which using standard I/O.
 type FileIORWManager struct {
 	fd          *os.File
-	path        string
+	path        nutspath.Path
 	fdm         *fdManager
 	segmentSize int64
 }

--- a/rwmanger_mmap.go
+++ b/rwmanger_mmap.go
@@ -16,13 +16,14 @@ package nutsdb
 
 import (
 	"errors"
+	"github.com/nutsdb/nutsdb/internal/nutspath"
 
 	mmap "github.com/xujiajun/mmap-go"
 )
 
 // MMapRWManager represents the RWManager which using mmap.
 type MMapRWManager struct {
-	path        string
+	path        nutspath.Path
 	fdm         *fdManager
 	m           mmap.MMap
 	segmentSize int64

--- a/tx.go
+++ b/tx.go
@@ -494,8 +494,12 @@ func (tx *Tx) rotateActiveFile() error {
 		return err
 	}
 
+	if err := tx.db.ActiveFile.rwManager.Close(); err != nil {
+		return err
+	}
+
 	// reset ActiveFile
-	path := getDataPath(tx.db.MaxFileID, tx.db.opt.Dir)
+	path := getDataPath(tx.db.MaxFileID, tx.db.opt.Dir.String())
 	tx.db.ActiveFile, err = tx.db.fm.getDataFile(path, tx.db.opt.SegmentSize)
 	if err != nil {
 		return err

--- a/tx_btree_test.go
+++ b/tx_btree_test.go
@@ -774,6 +774,8 @@ func TestTx_ExpiredDeletion(t *testing.T) {
 			txGet(t, db, bucket, GetTestBytes(1), GetTestBytes(1), nil)
 			txGet(t, db, bucket, GetTestBytes(3), GetTestBytes(3), nil)
 			txGet(t, db, bucket, GetTestBytes(4), GetTestBytes(4), nil)
+
+			db.Close()
 		})
 	})
 

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -186,11 +186,12 @@ func TestTx_LPop(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txPop(t, db, bucket, GetTestBytes(0), nil, ErrListNotFound, true)
+
+		db.Close()
 	})
 
 	// Insert some values for a key and validate them by using LPop
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
-		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, true)
 		for i := 0; i < 3; i++ {
 			txPop(t, db, bucket, GetTestBytes(0), GetTestBytes(2-i), nil, true)
@@ -205,11 +206,12 @@ func TestTx_RPop(t *testing.T) {
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		txPop(t, db, bucket, GetTestBytes(0), nil, ErrListNotFound, false)
+
+		db.Close()
 	})
 
 	// Calling RPop on a list with added data
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
-		txCreateBucket(t, db, DataStructureList, bucket, nil)
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, false)
 
 		txPop(t, db, "fake_bucket", GetTestBytes(0), nil, ErrBucketNotExist, false)
@@ -230,12 +232,12 @@ func TestTx_LRange(t *testing.T) {
 		txCreateBucket(t, db, DataStructureList, bucket, nil)
 
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 0, nil, ErrListNotFound)
+
+		db.Close()
 	})
 
 	// Calling LRange on a list with added data
 	runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
-		txCreateBucket(t, db, DataStructureList, bucket, nil)
-
 		pushDataByStartEnd(t, db, bucket, 0, 0, 2, true)
 
 		txLRange(t, db, bucket, GetTestBytes(0), 0, -1, 3, [][]byte{
@@ -250,6 +252,7 @@ func TestTx_LRange(t *testing.T) {
 	})
 }
 
+// FIXME: work bad on windows
 func TestTx_LRem(t *testing.T) {
 	bucket := "bucket"
 
@@ -327,6 +330,7 @@ func TestTx_LRem(t *testing.T) {
 	})
 }
 
+// FIXME: work bad on windows
 func TestTx_LTrim(t *testing.T) {
 	bucket := "bucket"
 
@@ -358,6 +362,7 @@ func TestTx_LTrim(t *testing.T) {
 	})
 }
 
+// FIXME: work bad on windows
 func TestTx_LSize(t *testing.T) {
 	bucket := "bucket"
 
@@ -375,6 +380,7 @@ func TestTx_LSize(t *testing.T) {
 	})
 }
 
+// FIXME: work bad on windows
 func TestTx_LRemByIndex(t *testing.T) {
 	bucket := "bucket"
 
@@ -411,6 +417,7 @@ func TestTx_LRemByIndex(t *testing.T) {
 	})
 }
 
+// FIXME: work bad on windows
 func TestTx_ExpireList(t *testing.T) {
 	bucket := "bucket"
 

--- a/utils.go
+++ b/utils.go
@@ -23,12 +23,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nutsdb/nutsdb/internal/nutspath"
+
 	"github.com/xujiajun/utils/strconv2"
 )
 
 // Truncate changes the size of the file.
-func Truncate(path string, capacity int64, f *os.File) error {
-	fileInfo, _ := os.Stat(path)
+func Truncate(path nutspath.Path, capacity int64, f *os.File) error {
+	fileInfo, _ := os.Stat(path.String())
 	if fileInfo.Size() < capacity {
 		if err := f.Truncate(capacity); err != nil {
 			return err
@@ -85,9 +87,8 @@ func MatchForRange(pattern, bucket string, f func(bucket string) bool) (end bool
 }
 
 // getDataPath returns the data path for the given file ID.
-func getDataPath(fID int64, dir string) string {
-	separator := string(filepath.Separator)
-	return dir + separator + strconv2.Int64ToStr(fID) + DataSuffix
+func getDataPath(fID int64, dir string) nutspath.Path {
+	return nutspath.New(dir).Join(strconv2.Int64ToStr(fID) + DataSuffix)
 }
 
 func OneOfUint16Array(value uint16, array []uint16) bool {


### PR DESCRIPTION
This late PR is for fixing #578 .

The superficial reason of this issue is: some places we use `filepath.Clean` and some places not. If we use `filepath.Clean` when we call `WithDir`, nutsdb will work good coincidentally.

In facts, there're more deeper reasons cause this reason. In one word, we don't close/release each file handler after it's used up. Windows is sensitive for these handlers. Of course, perhaps my understanding is incorrect.

Now I add more `xxx.Close()` for file handlers.

Another fact for approve my view above is many unit cases work bad on windows and some cases caused by the above `reason`. Them work good after my fix for file handlers.

Something more, for avoid non-standard handling of paths, I add a package named `nutsdbpath` to solve paths.

## Something Confused Me

I saw that some methods call multiple `runNutsDBTest` and the operation of creating bucket. Now I think we will throw errors if we do it. But there're many unit cases do these things.

## Advices for `runNutsDBTest`

There're some unit cases which call multiple `runNutsDBTest`, but the two calls are not associated. In this scene, it will work bad on windows. The `t.CleanUp` only run when all cases finished, so it may not useful enough.