### PR TITLE
feat(tx_btree.go): Added PrefixScanKeys function to optimize key scanning performance

### DIFF
--- a/tx_btree.go
+++ b/tx_btree.go
@@ -296,6 +296,33 @@ func (tx *Tx) PrefixScan(bucket string, prefix []byte, offsetNum int, limitNum i
 	return
 }
 
+// PrefixScanKeys iterates over a key prefix at given bucket, prefix and limitNum, only return keys.
+// LimitNum will limit the number of entries return.
+func (tx *Tx) PrefixScanKeys(bucket string, prefix []byte, offsetNum int, limitNum int) (keys [][]byte, err error) {
+	if err := tx.checkTxIsClosed(); err != nil {
+		return nil, err
+	}
+	b, err := tx.db.bm.GetBucket(DataStructureBTree, bucket)
+	if err != nil {
+		return nil, err
+	}
+	bucketId := b.Id
+
+	if idx, ok := tx.db.Index.bTree.exist(bucketId); ok {
+		records := idx.PrefixScan(prefix, offsetNum, limitNum)
+		keys, _, err = tx.getHintIdxDataItemsWrapper(records, limitNum, bucketId, true, false)
+		if err != nil {
+			return nil, ErrPrefixScan
+		}
+	}
+
+	if len(keys) == 0 {
+		return nil, ErrPrefixScan
+	}
+
+	return
+}
+
 // PrefixSearchScan iterates over a key prefix at given bucket, prefix, match regular expression and limitNum.
 // LimitNum will limit the number of entries return.
 func (tx *Tx) PrefixSearchScan(bucket string, prefix []byte, reg string, offsetNum int, limitNum int) (values [][]byte, err error) {


### PR DESCRIPTION
A new PrefixScanKeys function has been added to tx_btree.go, which is specifically used for prefix scanning of keys, improving performance and optimizing resource usage.
This change reduces unnecessary data processing by returning only keys instead of key-value pairs, and significantly improves efficiency, especially in high-load environments.