### PR TITLE
fix: record cannot be inserted after the expiration time is set

### DIFF
--- a/db.go
+++ b/db.go
@@ -606,8 +606,8 @@ func (db *DB) buildBTreeIdx(record *Record, entry *Entry) error {
 }
 
 func (db *DB) expireTime(timestamp uint64, ttl uint32) time.Duration {
-	now := time.UnixMilli(time.Now().UnixMilli())
-	expireTime := time.UnixMilli(int64(timestamp))
+	now := time.Unix(time.Now().Unix(), 0)
+	expireTime := time.Unix(int64(timestamp), 0)
 	expireTime = expireTime.Add(time.Duration(int64(ttl)) * time.Second)
 	return expireTime.Sub(now)
 }

--- a/record.go
+++ b/record.go
@@ -41,8 +41,8 @@ func IsExpired(ttl uint32, timestamp uint64) bool {
 		return false
 	}
 
-	now := time.UnixMilli(time.Now().UnixMilli())
-	expireTime := time.UnixMilli(int64(timestamp))
+	now := time.Now()
+	expireTime := time.Unix(int64(timestamp), 0)
 	expireTime = expireTime.Add(time.Duration(ttl) * time.Second)
 
 	return expireTime.Before(now)

--- a/record_test.go
+++ b/record_test.go
@@ -1,0 +1,31 @@
+package nutsdb
+
+import (
+	"testing"
+	"time"
+)
+
+// TestIsExpired tests the IsExpired function for different scenarios.
+func TestIsExpired(t *testing.T) {
+	tests := []struct {
+		ttl        uint32
+		timestamp  uint64
+		wantResult bool
+	}{
+		{ttl: 0, timestamp: 0, wantResult: false},
+		{ttl: 1, timestamp: 0, wantResult: true},
+		{ttl: 10, timestamp: 0, wantResult: true},
+		{ttl: Persistent, timestamp: 0, wantResult: false},
+		{ttl: 1, timestamp: uint64(time.Now().Unix()) + 2, wantResult: false},
+		{ttl: 1, timestamp: uint64(time.Now().Unix()) - 2, wantResult: true},
+		{ttl: 3, timestamp: uint64(time.Now().Unix()), wantResult: false},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if gotResult := IsExpired(tt.ttl, tt.timestamp); gotResult != tt.wantResult {
+				t.Errorf("IsExpired(%v, %v) = %v; want %v", tt.ttl, tt.timestamp, gotResult, tt.wantResult)
+			}
+		})
+	}
+}

--- a/tx_btree.go
+++ b/tx_btree.go
@@ -38,7 +38,7 @@ func (tx *Tx) PutWithTimestamp(bucket string, key, value []byte, ttl uint32, tim
 // Put sets the value for a key in the bucket.
 // a wrapper of the function put.
 func (tx *Tx) Put(bucket string, key, value []byte, ttl uint32) error {
-	return tx.put(bucket, key, value, ttl, DataSetFlag, uint64(time.Now().UnixMilli()), DataStructureBTree)
+	return tx.put(bucket, key, value, ttl, DataSetFlag, uint64(time.Now().Unix()), DataStructureBTree)
 }
 
 // PutIfNotExists set the value for a key in the bucket only if the key doesn't exist already.
@@ -63,7 +63,7 @@ func (tx *Tx) PutIfNotExists(bucket string, key, value []byte, ttl uint32) error
 		return nil
 	}
 
-	return tx.put(bucket, key, value, ttl, DataSetFlag, uint64(time.Now().UnixMilli()), DataStructureBTree)
+	return tx.put(bucket, key, value, ttl, DataSetFlag, uint64(time.Now().Unix()), DataStructureBTree)
 }
 
 // PutIfExits set the value for a key in the bucket only if the key already exits.

--- a/tx_btree_test.go
+++ b/tx_btree_test.go
@@ -1188,6 +1188,15 @@ func TestTx_MSetMGet(t *testing.T) {
 		})
 	})
 
+	t.Run("use MSet and MGet with 60s TTL", func(t *testing.T) {
+		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+			txMSet(t, db, bucket, nil, 60, nil, nil)
+			txMGet(t, db, bucket, nil, nil, nil, nil)
+		})
+	})
+
 	t.Run("use MSet by using odd number of args ", func(t *testing.T) {
 		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
 			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
@@ -1209,6 +1218,28 @@ func TestTx_MSetMGet(t *testing.T) {
 				GetTestBytes(0), GetTestBytes(2),
 			}, [][]byte{
 				GetTestBytes(1), GetTestBytes(3),
+			}, nil, nil)
+		})
+	})
+
+	t.Run("use MSet and MGet normally with TTL", func(t *testing.T) {
+		runNutsDBTest(t, nil, func(t *testing.T, db *DB) {
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+			txMSet(t, db, bucket, [][]byte{
+				GetTestBytes(0), GetTestBytes(1), GetTestBytes(2), GetTestBytes(3),
+			}, 2, nil, nil)
+			time.Sleep(2 * time.Second)
+			txMSet(t, db, bucket, [][]byte{
+				GetTestBytes(4), GetTestBytes(5), GetTestBytes(6), GetTestBytes(7),
+			}, 2, nil, nil)
+			txMGet(t, db, bucket, [][]byte{
+				GetTestBytes(0), GetTestBytes(2),
+			}, nil, ErrNotFoundKey, nil)
+			txMGet(t, db, bucket, [][]byte{
+				GetTestBytes(4), GetTestBytes(6),
+			}, [][]byte{
+				GetTestBytes(5), GetTestBytes(7),
 			}, nil, nil)
 		})
 	})


### PR DESCRIPTION
fix(record): use Unix time for expiration checks for issue #593 

Replace the usage of UnixMilli with Unix in record expiration checks to simplify the representation of timestamps. The previous implementation with UnixMilli led to unnecessary precision in the timestamp, which is not required for the expiration logic.
