### PR TITLE
Update README-CN.md for invalid documentation link.

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -12,7 +12,7 @@ NutsDB 是一个用纯 Go 编写的简单、快速、可嵌入且持久的键/�
 
 我们可以在NutsDB的文档网站了解更多：[NutsDB Documents](https://nutsdb.github.io/nutsdb-docs/)
 
-欢迎对NutsDB感兴趣的加群、一起开发，具体看这个issue：https://github.com/nutsdb/nutsdb/issues/116。
+欢迎对NutsDB感兴趣的加群、一起开发，具体看这个issue：https://github.com/nutsdb/nutsdb/issues/116 。
 
 ### 关注nutsdb公众号
  <img src="https://user-images.githubusercontent.com/6065007/221391600-4f53e966-c376-426e-9dec-27364a0704d1.png"   height = "300" alt="nutsdb公众号" align=center />
@@ -2445,3 +2445,4 @@ https://github.com/golang/go/wiki/CodeReviewComments
 ### License
 
 The NutsDB is open-sourced software licensed under the [Apache 2.0 license](https://github.com/nutsdb/nutsdb/blob/master/LICENSE).
+


### PR DESCRIPTION
in preview this link for issue 116 is unavailable due to full-width character period
<img width="1066" height="235" alt="image" src="https://github.com/user-attachments/assets/2d0df3a1-5791-49fb-81dc-ead8b79324e7" />
after add space between link and period, the link is ok.
<img width="616" height="55" alt="image" src="https://github.com/user-attachments/assets/700736fe-bc06-49ac-a6e9-02dbe806e995" />
