### PR TITLE
Fix low performance of mmap rwmode

### DIFF
--- a/file_manager.go
+++ b/file_manager.go
@@ -68,12 +68,7 @@ func (fm *fileManager) getMMapRWManager(path string, capacity int64, segmentSize
 		return nil, err
 	}
 
-	// m, err := mmap.Map(fd, mmap.RDWR, 0)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	return newMMapRWManager(fd, path, fm.fdm, segmentSize), nil
+	return getMMapRWManager(fd, path, fm.fdm, segmentSize), nil
 }
 
 // close will close fdm resource

--- a/file_manager.go
+++ b/file_manager.go
@@ -73,7 +73,7 @@ func (fm *fileManager) getMMapRWManager(path string, capacity int64, segmentSize
 	// 	return nil, err
 	// }
 
-	return &MMapRWManager{fd: fd, path: path, fdm: fm.fdm, segmentSize: segmentSize}, nil
+	return newMMapRWManager(fd, path, fm.fdm, segmentSize), nil
 }
 
 // close will close fdm resource

--- a/file_manager.go
+++ b/file_manager.go
@@ -1,9 +1,5 @@
 package nutsdb
 
-import (
-	"github.com/edsrzf/mmap-go"
-)
-
 // fileManager holds the fd cache and file-related operations go through the manager to obtain the file processing object
 type fileManager struct {
 	rwMode      RWMode
@@ -72,12 +68,12 @@ func (fm *fileManager) getMMapRWManager(path string, capacity int64, segmentSize
 		return nil, err
 	}
 
-	m, err := mmap.Map(fd, mmap.RDWR, 0)
-	if err != nil {
-		return nil, err
-	}
+	// m, err := mmap.Map(fd, mmap.RDWR, 0)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return &MMapRWManager{m: m, path: path, fdm: fm.fdm, segmentSize: segmentSize}, nil
+	return &MMapRWManager{fd: fd, path: path, fdm: fm.fdm, segmentSize: segmentSize}, nil
 }
 
 // close will close fdm resource

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -74,7 +74,7 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 
 	}
 
-	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
 	b := []byte("test write at")
 	off := int64(3)
 	n, err := mmManager.WriteAt(b, off)
@@ -107,7 +107,7 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 
 	}
 
-	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
 	m, err := mmap.Map(fd, mmap.RDWR, 0)
 	if err != nil {
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestRWManager_MMap_Close(t *testing.T) {
 
 	}
 
-	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
 	err = mmManager.Close()
 	err = isFileDescriptorClosed(fd.Fd())
 	if err == nil {

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -73,12 +73,8 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 		require.NoError(t, err)
 
 	}
-	m, err := mmap.Map(fd, mmap.RDWR, 0)
-	if err != nil {
-		require.NoError(t, err)
-	}
 
-	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
+	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
 	b := []byte("test write at")
 	off := int64(3)
 	n, err := mmManager.WriteAt(b, off)
@@ -86,6 +82,10 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Equal(t, len(b), n)
+	m, err := mmap.Map(fd, mmap.RDWR, 0)
+	if err != nil {
+		require.NoError(t, err)
+	}
 	require.Equal(t, append([]byte{0, 0, 0}, b...), []byte(m[:off+int64(len(b))]))
 }
 
@@ -106,12 +106,12 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 		require.NoError(t, err)
 
 	}
+
+	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
 	m, err := mmap.Map(fd, mmap.RDWR, 0)
 	if err != nil {
 		require.NoError(t, err)
 	}
-
-	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
 	m[1] = 'z'
 	err = mmManager.Sync()
 	require.NoError(t, err)
@@ -137,12 +137,8 @@ func TestRWManager_MMap_Close(t *testing.T) {
 		require.NoError(t, err)
 
 	}
-	m, err := mmap.Map(fd, mmap.RDWR, 0)
-	if err != nil {
-		require.NoError(t, err)
-	}
 
-	mmManager := &MMapRWManager{filePath, fdm, m, 256 * MB}
+	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
 	err = mmManager.Close()
 	err = isFileDescriptorClosed(fd.Fd())
 	if err == nil {

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -74,7 +74,7 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 
 	}
 
-	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
+	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
 	b := []byte("test write at")
 	off := int64(3)
 	n, err := mmManager.WriteAt(b, off)
@@ -107,7 +107,7 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 
 	}
 
-	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
+	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
 	m, err := mmap.Map(fd, mmap.RDWR, 0)
 	if err != nil {
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestRWManager_MMap_Close(t *testing.T) {
 
 	}
 
-	mmManager := &MMapRWManager{fd, filePath, fdm, 256 * MB}
+	mmManager := newMMapRWManager(fd, filePath, fdm, 256*MB)
 	err = mmManager.Close()
 	err = isFileDescriptorClosed(fd.Fd())
 	if err == nil {

--- a/rwmanager_mmap_test.go
+++ b/rwmanager_mmap_test.go
@@ -15,7 +15,9 @@
 package nutsdb
 
 import (
+	"errors"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,8 +27,8 @@ import (
 
 func TestRWManager_MMap_Release(t *testing.T) {
 	filePath := "/tmp/foo_rw_MMap"
-	fdm := newFileManager(MMap, 1024, 0.5, 256*MB)
-	rwmanager, err := fdm.getMMapRWManager(filePath, 1024, 256*MB)
+	fdm := newFileManager(MMap, 8*MB, 0.5, 8*MB)
+	rwmanager, err := fdm.getMMapRWManager(filePath, 8*MB, 8*MB)
 	if err != nil {
 		t.Error("err TestRWManager_MMap_Release getMMapRWManager")
 	}
@@ -68,13 +70,13 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 	}
 	defer os.Remove(fd.Name())
 
-	err = Truncate(filePath, 1024, fd)
+	err = Truncate(filePath, 8*MB, fd)
 	if err != nil {
 		require.NoError(t, err)
 
 	}
 
-	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
 	b := []byte("test write at")
 	off := int64(3)
 	n, err := mmManager.WriteAt(b, off)
@@ -89,6 +91,120 @@ func TestRWManager_MMap_WriteAt(t *testing.T) {
 	require.Equal(t, append([]byte{0, 0, 0}, b...), []byte(m[:off+int64(len(b))]))
 }
 
+func TestRWManager_MMap_WriteAt_NotEnoughData(t *testing.T) {
+	filePath := path.Join(t.TempDir(), "rw_mmap")
+	maxFdNums := 1024
+	cleanThreshold := 0.5
+	var fdm = newFdm(maxFdNums, cleanThreshold)
+
+	fd, err := fdm.getFd(filePath)
+	require.NoError(t, err)
+
+	defer os.Remove(fd.Name())
+
+	err = Truncate(filePath, 8*MB, fd)
+	require.NoError(t, err)
+
+	m, err := mmap.Map(fd, mmap.RDWR, 0)
+	require.NoError(t, err)
+
+	b := []byte("test-data-message")
+	off := int64(8*MB - 4)
+	copy(m[off:], b)
+
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
+
+	n, err := mmManager.WriteAt(b, off)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	data := make([]byte, n)
+	copy(data, m[off:])
+	require.Equal(t, b[:n], data)
+}
+
+func TestRWManager_MMap_ReadAt_CrossBlock(t *testing.T) {
+	filePath := path.Join(t.TempDir(), "rw_mmap")
+	maxFdNums := 1024
+	cleanThreshold := 0.5
+	var fdm = newFdm(maxFdNums, cleanThreshold)
+
+	fd, err := fdm.getFd(filePath)
+	require.NoError(t, err)
+
+	defer os.Remove(fd.Name())
+
+	err = Truncate(filePath, 8*MB, fd)
+	require.NoError(t, err)
+
+	m, err := mmap.Map(fd, mmap.RDWR, 0)
+	require.NoError(t, err)
+
+	b := []byte("test-data-message")
+	off := int64(mmapBlockSize - 5)
+	copy(m[off:], b)
+
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
+
+	data := make([]byte, len(b))
+	n, err := mmManager.ReadAt(data, off)
+	require.NoError(t, err)
+	require.Equal(t, len(b), n)
+	require.Equal(t, b, data)
+}
+
+func TestRWManager_MMap_ReadAt_NotEnoughBytes(t *testing.T) {
+	filePath := path.Join(t.TempDir(), "rw_mmap")
+	maxFdNums := 1024
+	cleanThreshold := 0.5
+	var fdm = newFdm(maxFdNums, cleanThreshold)
+
+	fd, err := fdm.getFd(filePath)
+	require.NoError(t, err)
+
+	defer os.Remove(fd.Name())
+
+	err = Truncate(filePath, 8*MB, fd)
+	require.NoError(t, err)
+
+	m, err := mmap.Map(fd, mmap.RDWR, 0)
+	require.NoError(t, err)
+
+	b := []byte("test")
+	off := int64(8*MB - 4)
+	copy(m[off:], b)
+
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
+
+	data := make([]byte, 10)
+	n, err := mmManager.ReadAt(data, off)
+	require.NoError(t, err)
+	require.Equal(t, len(b), n)
+	require.Equal(t, b, data[0:4])
+}
+
+func TestRWManager_MMap_ReadAt_ErrIndexOutOfBound(t *testing.T) {
+	filePath := path.Join(t.TempDir(), "rw_mmap")
+	maxFdNums := 1024
+	cleanThreshold := 0.5
+	var fdm = newFdm(maxFdNums, cleanThreshold)
+
+	fd, err := fdm.getFd(filePath)
+	require.NoError(t, err)
+
+	defer os.Remove(fd.Name())
+
+	err = Truncate(filePath, 8*MB, fd)
+	require.NoError(t, err)
+
+	b := make([]byte, 16)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
+	_, err = mmManager.ReadAt(b, 9*MB)
+	require.True(t, errors.Is(err, ErrIndexOutOfBound))
+	_, err = mmManager.ReadAt(b, -1)
+	require.True(t, errors.Is(err, ErrIndexOutOfBound))
+}
+
 func TestRWManager_MMap_Sync(t *testing.T) {
 	filePath := "/tmp/foo_rw_filemmap"
 	maxFdNums := 1024
@@ -101,13 +217,13 @@ func TestRWManager_MMap_Sync(t *testing.T) {
 	}
 	defer os.Remove(fd.Name())
 
-	err = Truncate(filePath, 1024, fd)
+	err = Truncate(filePath, 8*MB, fd)
 	if err != nil {
 		require.NoError(t, err)
 
 	}
 
-	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
 	m, err := mmap.Map(fd, mmap.RDWR, 0)
 	if err != nil {
 		require.NoError(t, err)
@@ -132,13 +248,13 @@ func TestRWManager_MMap_Close(t *testing.T) {
 	}
 	defer os.Remove(fd.Name())
 
-	err = Truncate(filePath, 1024, fd)
+	err = Truncate(filePath, 8*MB, fd)
 	if err != nil {
 		require.NoError(t, err)
 
 	}
 
-	mmManager := getMMapRWManager(fd, filePath, fdm, 256*MB)
+	mmManager := getMMapRWManager(fd, filePath, fdm, 8*MB)
 	err = mmManager.Close()
 	err = isFileDescriptorClosed(fd.Fd())
 	if err == nil {


### PR DESCRIPTION
Before fix:
<img width="1599" height="367" alt="image" src="https://github.com/user-attachments/assets/c9f37389-7ce2-41f7-a134-cc404b2eb46d" />


After fix:
<img width="1588" height="348" alt="image" src="https://github.com/user-attachments/assets/675b5c05-c196-4ece-bb82-e4bbd18c35d3" />


fix design:
before fix, for each get / write operation will generate a new mmap instance, it will make operation very slow. 
after that, we make mmapRWManager as a singleton for each data file. And for each mmapRWManager, I split data file as many part of mmap.   