### PR TITLE
iterator: add release method

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -28,6 +28,8 @@ type IteratorOptions struct {
 	Reverse bool
 }
 
+// Returns a new iterator.
+// The Release method must be called finished with iterator.
 func NewIterator(tx *Tx, bucket string, options IteratorOptions) *Iterator {
 	b, err := tx.db.bm.GetBucket(DataStructureBTree, bucket)
 	if err != nil {
@@ -78,4 +80,8 @@ func (it *Iterator) Key() []byte {
 
 func (it *Iterator) Value() ([]byte, error) {
 	return it.tx.db.getValueByRecord(it.iter.Item().record)
+}
+
+func (it *Iterator) Release() {
+	it.iter.Release()
 }

--- a/iterator.go
+++ b/iterator.go
@@ -29,7 +29,7 @@ type IteratorOptions struct {
 }
 
 // Returns a new iterator.
-// The Release method must be called finished with iterator.
+// The Release method must be called when finished with the iterator.
 func NewIterator(tx *Tx, bucket string, options IteratorOptions) *Iterator {
 	b, err := tx.db.bm.GetBucket(DataStructureBTree, bucket)
 	if err != nil {


### PR DESCRIPTION
The nutsDB iterator utilizes the iterator returned from [btree.Iter()](https://github.com/tidwall/btree/blob/9ce5205f5d8c8524e59d0049fa5a318d29b97348/btreeg.go#L1579) method internally. As per the documentation:
```
Iter returns a read-only iterator. The Release method must be called finished with iterator.
```
However, there is no method to release the internal iterator, which effectively blocks any subsequent operations on the bucket / values that were iterated.

-----

This PR addresses this issue by introducing a Release() method that should be called after we are done with the iterator. Also corrected the tests to use Release, as well as a specific test solely for the purpose of validating the new method.