### PR TITLE
feat: Implement V2 Merge Functionality with Manifest Support and HintFile with both of Merge and V2 Merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 testdata/
 bin/
 */*.DS_Store
+.gocache

--- a/db_test.go
+++ b/db_test.go
@@ -1734,7 +1734,7 @@ func TestDB_HintFileMissingFallback(t *testing.T) {
 	// Remove hint files to simulate missing hint files
 	_, fileIDs := db.getMaxFileIDAndFileIDs()
 	for _, fileID := range fileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
+		hintPath := getHintPath(fileID, opts.Dir)
 		os.Remove(hintPath)
 	}
 
@@ -1786,7 +1786,7 @@ func TestDB_HintFileCorruptedFallback(t *testing.T) {
 	// Corrupt hint files to simulate corrupted hint files
 	_, fileIDs := db.getMaxFileIDAndFileIDs()
 	for _, fileID := range fileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
+		hintPath := getHintPath(fileID, opts.Dir)
 		// Write garbage data to corrupt the file
 		err := os.WriteFile(hintPath, []byte{0xFF, 0xFF, 0xFF}, 0644)
 		require.NoError(t, err)
@@ -1987,7 +1987,7 @@ func TestDB_HintFileDisabled(t *testing.T) {
 	// Verify no hint files are created
 	_, fileIDs := db.getMaxFileIDAndFileIDs()
 	for _, fileID := range fileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
+		hintPath := getHintPath(fileID, opts.Dir)
 		_, err := os.Stat(hintPath)
 		if err == nil {
 			t.Errorf("Hint file %s should not exist when EnableHintFile is false", hintPath)

--- a/entry.go
+++ b/entry.go
@@ -238,8 +238,15 @@ func (e *Entry) GetTxIDBytes() []byte {
 	return []byte(strconv2.Int64ToStr(int64(e.Meta.TxID)))
 }
 
+func (e *Entry) IsBelongsToBTree() bool {
+	return e.Meta.IsBTree()
+}
+
+// IsBelongsToBPlusTree is kept for backward compatibility with legacy naming.
+// Internally nutsdb uses a B+ tree implementation for primary indexes, so both
+// helpers map to the same metadata flag.
 func (e *Entry) IsBelongsToBPlusTree() bool {
-	return e.Meta.IsBPlusTree()
+	return e.IsBelongsToBTree()
 }
 
 func (e *Entry) IsBelongsToList() bool {

--- a/file_manager.go
+++ b/file_manager.go
@@ -42,6 +42,11 @@ func (fm *fileManager) getDataFile(path string, capacity int64) (datafile *DataF
 	return NewDataFile(path, rwManager), nil
 }
 
+func (fm *fileManager) getDataFileByID(dir string, fileID int64, capacity int64) (*DataFile, error) {
+	path := getDataPath(fileID, dir)
+	return fm.getDataFile(path, capacity)
+}
+
 // getFileRWManager will return a FileIORWManager Object
 func (fm *fileManager) getFileRWManager(path string, capacity int64, segmentSize int64) (*FileIORWManager, error) {
 	fd, err := fm.fdm.getFd(path)

--- a/hint_collector.go
+++ b/hint_collector.go
@@ -1,0 +1,100 @@
+package nutsdb
+
+import "errors"
+
+var errHintCollectorClosed = errors.New("hint collector closed")
+
+const DefaultHintCollectorFlushEvery = 1024
+
+type hintWriter interface {
+	Write(*HintEntry) error
+	Sync() error
+	Close() error
+}
+
+type HintCollector struct {
+	writer     hintWriter
+	buf        []HintEntry
+	fileID     int64
+	flushEvery int
+	closed     bool
+}
+
+func NewHintCollector(fileID int64, writer hintWriter, flushEvery int) *HintCollector {
+	if flushEvery <= 0 {
+		flushEvery = DefaultHintCollectorFlushEvery
+	}
+	return &HintCollector{
+		writer:     writer,
+		buf:        make([]HintEntry, 0, flushEvery),
+		fileID:     fileID,
+		flushEvery: flushEvery,
+	}
+}
+
+func (hc *HintCollector) Add(entry *HintEntry) error {
+	if hc.closed {
+		return errHintCollectorClosed
+	}
+	if entry == nil {
+		return ErrHintFileEntryInvalid
+	}
+	clone := *entry
+	clone.FileID = hc.fileID
+	if len(entry.Key) > 0 {
+		clone.Key = append([]byte(nil), entry.Key...)
+	}
+	hc.buf = append(hc.buf, clone)
+	if len(hc.buf) >= hc.flushEvery {
+		return hc.flush(true)
+	}
+	return nil
+}
+
+func (hc *HintCollector) Flush() error {
+	if hc.closed {
+		return errHintCollectorClosed
+	}
+	return hc.flush(true)
+}
+
+func (hc *HintCollector) Sync() error {
+	if hc.closed {
+		return errHintCollectorClosed
+	}
+	if err := hc.flush(false); err != nil {
+		return err
+	}
+	return hc.writer.Sync()
+}
+
+func (hc *HintCollector) Close() error {
+	if hc.closed {
+		return nil
+	}
+	if err := hc.flush(true); err != nil {
+		return err
+	}
+	hc.closed = true
+	return hc.writer.Close()
+}
+
+func (hc *HintCollector) flush(sync bool) error {
+	if len(hc.buf) == 0 {
+		if sync {
+			return hc.writer.Sync()
+		}
+		return nil
+	}
+	for i := range hc.buf {
+		entry := hc.buf[i]
+		if err := hc.writer.Write(&entry); err != nil {
+			return err
+		}
+	}
+	hc.buf = hc.buf[:0]
+	if sync {
+		return hc.writer.Sync()
+	}
+	return nil
+}

--- a/hint_collector_test.go
+++ b/hint_collector_test.go
@@ -1,0 +1,96 @@
+package nutsdb
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockHintWriter struct {
+	entries []*HintEntry
+	synced  int
+	closed  bool
+}
+
+func (m *mockHintWriter) Create(string) error { return nil }
+
+func (m *mockHintWriter) Write(entry *HintEntry) error {
+	clone := *entry
+	if len(entry.Key) > 0 {
+		clone.Key = append([]byte(nil), entry.Key...)
+	}
+	m.entries = append(m.entries, &clone)
+	return nil
+}
+
+func (m *mockHintWriter) Sync() error {
+	m.synced++
+	return nil
+}
+
+func (m *mockHintWriter) Close() error {
+	m.closed = true
+	return nil
+}
+
+func TestHintCollectorFlushEvery(t *testing.T) {
+	writer := &mockHintWriter{}
+	collector := &HintCollector{writer: writer, buf: make([]HintEntry, 0, 2), fileID: 42, flushEvery: 2}
+
+	entry := &HintEntry{Key: []byte("foo")}
+	if err := collector.Add(entry); err != nil {
+		t.Fatalf("add returned error: %v", err)
+	}
+	if len(writer.entries) != 0 {
+		t.Fatalf("expected no flush before threshold, got %d entries", len(writer.entries))
+	}
+
+	if err := collector.Add(&HintEntry{Key: []byte("bar")}); err != nil {
+		t.Fatalf("add returned error: %v", err)
+	}
+
+	if len(writer.entries) != 2 {
+		t.Fatalf("expected 2 flushed entries, got %d", len(writer.entries))
+	}
+
+	if !bytes.Equal(writer.entries[0].Key, []byte("foo")) || writer.entries[0].FileID != 42 {
+		t.Fatalf("unexpected first entry: %+v", writer.entries[0])
+	}
+	if !bytes.Equal(writer.entries[1].Key, []byte("bar")) || writer.entries[1].FileID != 42 {
+		t.Fatalf("unexpected second entry: %+v", writer.entries[1])
+	}
+	if writer.synced != 1 {
+		t.Fatalf("expected 1 sync, got %d", writer.synced)
+	}
+}
+
+func TestHintCollectorFlushAndClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.hint")
+	writer := &HintFileWriter{}
+	if err := writer.Create(path); err != nil {
+		t.Fatalf("create writer: %v", err)
+	}
+
+	collector := NewHintCollector(7, writer, 2)
+
+	if err := collector.Add(&HintEntry{Key: []byte("a")}); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := collector.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	if err := collector.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hint file: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("hint file empty")
+	}
+}

--- a/hintfile.go
+++ b/hintfile.go
@@ -1,0 +1,378 @@
+// Copyright 2019 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/xujiajun/utils/strconv2"
+)
+
+const (
+	// HintSuffix returns the hint file suffix
+	HintSuffix = ".hint"
+)
+
+var (
+	// ErrHintFileCorrupted is returned when hint file is corrupted
+	ErrHintFileCorrupted = errors.New("hint file is corrupted")
+	// ErrHintFileEntryInvalid is returned when hint entry is invalid
+	ErrHintFileEntryInvalid = errors.New("hint file entry is invalid")
+)
+
+// getHintPath returns the hint file path for the given file ID and directory
+func getHintPath(fid int64, dir string) string {
+	separator := string(filepath.Separator)
+	return dir + separator + strconv2.Int64ToStr(fid) + HintSuffix
+}
+
+// HintEntry represents an entry in the hint file
+type HintEntry struct {
+	BucketId  uint64
+	KeySize   uint32
+	ValueSize uint32
+	Timestamp uint64
+	TTL       uint32
+	Flag      uint16
+	Status    uint16
+	Ds        uint16
+	DataPos   uint64
+	FileID    int64
+	Key       []byte
+}
+
+// Size returns the size of the hint entry
+func (h *HintEntry) Size() int64 {
+	keySize := len(h.Key)
+
+	size := 0
+	size += UvarintSize(h.BucketId)
+	size += UvarintSize(uint64(keySize))
+	size += UvarintSize(uint64(h.ValueSize))
+	size += UvarintSize(h.Timestamp)
+	size += UvarintSize(uint64(h.TTL))
+	size += UvarintSize(uint64(h.Flag))
+	size += UvarintSize(uint64(h.Status))
+	size += UvarintSize(uint64(h.Ds))
+	size += UvarintSize(h.DataPos)
+	size += UvarintSize(uint64(h.FileID))
+	size += keySize
+
+	return int64(size)
+}
+
+// Encode encodes the hint entry to bytes
+func (h *HintEntry) Encode() []byte {
+	keySize := len(h.Key)
+	h.KeySize = uint32(keySize)
+
+	buf := make([]byte, h.Size())
+	index := 0
+
+	index += binary.PutUvarint(buf[index:], h.BucketId)
+	index += binary.PutUvarint(buf[index:], uint64(keySize))
+	index += binary.PutUvarint(buf[index:], uint64(h.ValueSize))
+	index += binary.PutUvarint(buf[index:], h.Timestamp)
+	index += binary.PutUvarint(buf[index:], uint64(h.TTL))
+	index += binary.PutUvarint(buf[index:], uint64(h.Flag))
+	index += binary.PutUvarint(buf[index:], uint64(h.Status))
+	index += binary.PutUvarint(buf[index:], uint64(h.Ds))
+	index += binary.PutUvarint(buf[index:], h.DataPos)
+	index += binary.PutUvarint(buf[index:], uint64(h.FileID))
+
+	copy(buf[index:], h.Key)
+	index += keySize
+
+	return buf[:index]
+}
+
+// Decode decodes the hint entry from bytes
+func (h *HintEntry) Decode(buf []byte) error {
+	if len(buf) == 0 {
+		return ErrHintFileEntryInvalid
+	}
+
+	index := 0
+
+	bucketId, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.BucketId = bucketId
+
+	keySize, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.KeySize = uint32(keySize)
+
+	valueSize, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.ValueSize = uint32(valueSize)
+
+	timestamp, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.Timestamp = timestamp
+
+	ttl, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.TTL = uint32(ttl)
+
+	flag, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.Flag = uint16(flag)
+
+	status, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.Status = uint16(status)
+
+	ds, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.Ds = uint16(ds)
+
+	dataPos, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.DataPos = dataPos
+
+	fileID, n := binary.Uvarint(buf[index:])
+	if n <= 0 {
+		return ErrHintFileCorrupted
+	}
+	index += n
+	h.FileID = int64(fileID)
+
+	if len(buf) < index+int(h.KeySize) {
+		return ErrHintFileCorrupted
+	}
+
+	h.Key = make([]byte, h.KeySize)
+	copy(h.Key, buf[index:index+int(h.KeySize)])
+
+	return nil
+}
+
+// HintFileReader is used to read hint files
+type HintFileReader struct {
+	file   *os.File
+	reader *bufio.Reader
+}
+
+// Open opens a hint file for reading
+func (r *HintFileReader) Open(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	r.file = file
+	r.reader = bufio.NewReader(file)
+
+	return nil
+}
+
+// Read reads a hint entry from the file
+func (r *HintFileReader) Read() (*HintEntry, error) {
+	if r.reader == nil {
+		return nil, ErrHintFileEntryInvalid
+	}
+
+	entry := &HintEntry{}
+	fieldsRead := 0
+
+	readUvarint := func() (uint64, error) {
+		val, err := binary.ReadUvarint(r.reader)
+		if err != nil {
+			if err == io.EOF {
+				if fieldsRead == 0 {
+					return 0, io.EOF
+				}
+				return 0, ErrHintFileCorrupted
+			}
+			if err == io.ErrUnexpectedEOF {
+				return 0, ErrHintFileCorrupted
+			}
+			return 0, err
+		}
+		fieldsRead++
+		return val, nil
+	}
+
+	var err error
+	if entry.BucketId, err = readUvarint(); err != nil {
+		return nil, err
+	}
+
+	keySize, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.KeySize = uint32(keySize)
+
+	valueSize, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.ValueSize = uint32(valueSize)
+
+	if entry.Timestamp, err = readUvarint(); err != nil {
+		return nil, err
+	}
+
+	ttl, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.TTL = uint32(ttl)
+
+	flag, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.Flag = uint16(flag)
+
+	status, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.Status = uint16(status)
+
+	ds, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.Ds = uint16(ds)
+
+	if entry.DataPos, err = readUvarint(); err != nil {
+		return nil, err
+	}
+
+	fileID, err := readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	entry.FileID = int64(fileID)
+
+	if entry.KeySize > 0 {
+		entry.Key = make([]byte, entry.KeySize)
+		if _, err := io.ReadFull(r.reader, entry.Key); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return nil, ErrHintFileCorrupted
+			}
+			return nil, err
+		}
+	}
+
+	return entry, nil
+}
+
+// Close closes the hint file
+func (r *HintFileReader) Close() error {
+	if r.file != nil {
+		return r.file.Close()
+	}
+	return nil
+}
+
+// HintFileWriter is used to write hint files
+type HintFileWriter struct {
+	file   *os.File
+	writer *bufio.Writer
+}
+
+// Create creates a hint file for writing
+func (w *HintFileWriter) Create(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	w.file = file
+	w.writer = bufio.NewWriter(file)
+
+	return nil
+}
+
+// Write writes a hint entry to the file
+func (w *HintFileWriter) Write(entry *HintEntry) error {
+	if entry == nil {
+		return ErrHintFileEntryInvalid
+	}
+
+	data := entry.Encode()
+	_, err := w.writer.Write(data)
+	return err
+}
+
+// Sync flushes the buffer and syncs the file to disk
+func (w *HintFileWriter) Sync() error {
+	if w.writer != nil {
+		if err := w.writer.Flush(); err != nil {
+			return err
+		}
+	}
+
+	if w.file != nil {
+		return w.file.Sync()
+	}
+
+	return nil
+}
+
+// Close closes the hint file
+func (w *HintFileWriter) Close() error {
+	var err error
+
+	if w.writer != nil {
+		if flushErr := w.writer.Flush(); flushErr != nil {
+			err = flushErr
+		}
+	}
+
+	if w.file != nil {
+		if closeErr := w.file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}
+
+	return err
+}

--- a/hintfile_bench_test.go
+++ b/hintfile_bench_test.go
@@ -1,0 +1,503 @@
+// Copyright 2023 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// BenchmarkHintFileEncode benchmarks the encoding of HintEntry
+func BenchmarkHintFileEncode(b *testing.B) {
+	entry := &HintEntry{
+		BucketId:  1,
+		KeySize:   10,
+		ValueSize: 100,
+		Timestamp: uint64(time.Now().UnixMilli()),
+		TTL:       3600,
+		Flag:      DataSetFlag,
+		Status:    Committed,
+		Ds:        DataStructureBTree,
+		DataPos:   1000,
+		FileID:    1,
+		Key:       []byte("testkey123"),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = entry.Encode()
+	}
+}
+
+// BenchmarkHintFileDecode benchmarks the decoding of HintEntry
+func BenchmarkHintFileDecode(b *testing.B) {
+	entry := &HintEntry{
+		BucketId:  1,
+		KeySize:   10,
+		ValueSize: 100,
+		Timestamp: uint64(time.Now().UnixMilli()),
+		TTL:       3600,
+		Flag:      DataSetFlag,
+		Status:    Committed,
+		Ds:        DataStructureBTree,
+		DataPos:   1000,
+		FileID:    1,
+		Key:       []byte("testkey123"),
+	}
+
+	encoded := entry.Encode()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decoded := &HintEntry{}
+		_ = decoded.Decode(encoded)
+	}
+}
+
+// BenchmarkHintFileWrite benchmarks writing hint entries to file
+func BenchmarkHintFileWrite(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-write")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hintPath := tmpDir + "/test.hint"
+
+	entries := make([]*HintEntry, 1000)
+	for i := 0; i < 1000; i++ {
+		entries[i] = &HintEntry{
+			BucketId:  1,
+			KeySize:   10,
+			ValueSize: 100,
+			Timestamp: uint64(time.Now().UnixMilli()),
+			TTL:       3600,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureBTree,
+			DataPos:   uint64(i * 10),
+			FileID:    1,
+			Key:       []byte(fmt.Sprintf("key%d", i)),
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		writer := &HintFileWriter{}
+		err := writer.Create(hintPath)
+		if err != nil {
+			b.Fatalf("Failed to create hint file: %v", err)
+		}
+
+		for _, entry := range entries {
+			err := writer.Write(entry)
+			if err != nil {
+				b.Fatalf("Failed to write hint entry: %v", err)
+			}
+		}
+
+		err = writer.Close()
+		if err != nil {
+			b.Fatalf("Failed to close hint file: %v", err)
+		}
+
+		os.Remove(hintPath)
+	}
+}
+
+// BenchmarkHintFileRead benchmarks reading hint entries from file
+func BenchmarkHintFileRead(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-read")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hintPath := tmpDir + "/test.hint"
+
+	// Create a hint file with 1000 entries
+	writer := &HintFileWriter{}
+	err = writer.Create(hintPath)
+	if err != nil {
+		b.Fatalf("Failed to create hint file: %v", err)
+	}
+
+	entries := make([]*HintEntry, 1000)
+	for i := 0; i < 1000; i++ {
+		entries[i] = &HintEntry{
+			BucketId:  1,
+			KeySize:   10,
+			ValueSize: 100,
+			Timestamp: uint64(time.Now().UnixMilli()),
+			TTL:       3600,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureBTree,
+			DataPos:   uint64(i * 10),
+			FileID:    1,
+			Key:       []byte(fmt.Sprintf("key%d", i)),
+		}
+
+		err := writer.Write(entries[i])
+		if err != nil {
+			b.Fatalf("Failed to write hint entry: %v", err)
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		b.Fatalf("Failed to close hint file: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader := &HintFileReader{}
+		err := reader.Open(hintPath)
+		if err != nil {
+			b.Fatalf("Failed to open hint file: %v", err)
+		}
+
+		count := 0
+		for {
+			_, err := reader.Read()
+			if err != nil {
+				break
+			}
+			count++
+		}
+
+		if count != 1000 {
+			b.Fatalf("Expected to read 1000 entries, got %d", count)
+		}
+
+		err = reader.Close()
+		if err != nil {
+			b.Fatalf("Failed to close hint file: %v", err)
+		}
+	}
+}
+
+// BenchmarkDBStartupWithHintFile benchmarks database startup with hint files
+func BenchmarkDBStartupWithHintFile(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-startup")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	opts := DefaultOptions
+	opts.Dir = tmpDir
+	opts.SegmentSize = 64 * KB
+	opts.EnableHintFile = true
+	opts.EntryIdxMode = HintKeyAndRAMIdxMode
+
+	// Prepare database with data and hint files
+	start := time.Now()
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Failed to open database: %v", err)
+	}
+	openTime := time.Since(start)
+
+	bucket := "bucket"
+	txCreateBucket(&testing.T{}, db, DataStructureBTree, bucket, nil)
+
+	// Add enough data to trigger merge
+	start = time.Now()
+	for i := 0; i < 5000000; i++ {
+		txPut(&testing.T{}, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+	insertTime := time.Since(start)
+	b.Logf("插入阶段耗时: %v", insertTime)
+
+	// Perform merge to create hint files
+	start = time.Now()
+	err = db.Merge()
+	if err != nil {
+		b.Fatalf("Failed to merge: %v", err)
+	}
+	mergeTime := time.Since(start)
+	b.Logf("Merge阶段耗时: %v", mergeTime)
+
+	start = time.Now()
+	err = db.Close()
+	if err != nil {
+		b.Fatalf("Failed to close database: %v", err)
+	}
+	closeTime := time.Since(start)
+	b.Logf("初始关闭耗时: %v", closeTime)
+	b.Logf("初始打开耗时: %v", openTime)
+
+	b.ResetTimer()
+	var totalStartupTime time.Duration
+	for i := 0; i < b.N; i++ {
+		start = time.Now()
+		db, err := Open(opts)
+		if err != nil {
+			b.Fatalf("Failed to open database: %v", err)
+		}
+		startupTime := time.Since(start)
+		totalStartupTime += startupTime
+
+		err = db.Close()
+		if err != nil {
+			b.Fatalf("Failed to close database: %v", err)
+		}
+	}
+	avgStartupTime := totalStartupTime / time.Duration(b.N)
+	b.Logf("平均重新启动耗时: %v", avgStartupTime)
+}
+
+// BenchmarkDBStartupWithoutHintFile benchmarks database startup without hint files
+func BenchmarkDBStartupWithoutHintFile(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-startup-no-hint")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	opts := DefaultOptions
+	opts.Dir = tmpDir
+	opts.SegmentSize = 64 * KB
+	opts.EntryIdxMode = HintKeyAndRAMIdxMode
+	opts.EnableHintFile = false
+
+	// Prepare database with data but no hint files
+	start := time.Now()
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Failed to open database: %v", err)
+	}
+	openTime := time.Since(start)
+
+	bucket := "bucket"
+	txCreateBucket(&testing.T{}, db, DataStructureBTree, bucket, nil)
+
+	// Add enough data to trigger merge
+	start = time.Now()
+	for i := 0; i < 5000000; i++ {
+		txPut(&testing.T{}, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+	insertTime := time.Since(start)
+	b.Logf("插入阶段耗时: %v", insertTime)
+
+	// Perform merge (should not create hint files)
+	start = time.Now()
+	err = db.Merge()
+	if err != nil {
+		b.Fatalf("Failed to merge: %v", err)
+	}
+	mergeTime := time.Since(start)
+	b.Logf("Merge阶段耗时: %v", mergeTime)
+
+	start = time.Now()
+	err = db.Close()
+	if err != nil {
+		b.Fatalf("Failed to close database: %v", err)
+	}
+	closeTime := time.Since(start)
+	b.Logf("初始关闭耗时: %v", closeTime)
+	b.Logf("初始打开耗时: %v", openTime)
+
+	b.ResetTimer()
+	var totalStartupTime time.Duration
+	for i := 0; i < b.N; i++ {
+		start = time.Now()
+		db, err := Open(opts)
+		if err != nil {
+			b.Fatalf("Failed to open database: %v", err)
+		}
+		startupTime := time.Since(start)
+		totalStartupTime += startupTime
+
+		err = db.Close()
+		if err != nil {
+			b.Fatalf("Failed to close database: %v", err)
+		}
+	}
+	avgStartupTime := totalStartupTime / time.Duration(b.N)
+	b.Logf("平均重新启动耗时: %v", avgStartupTime)
+}
+
+// BenchmarkMergeWithHintFile benchmarks merge operation with hint files enabled
+func BenchmarkMergeWithHintFile(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-merge")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	opts := DefaultOptions
+	opts.Dir = tmpDir
+	opts.SegmentSize = 64 * KB
+	opts.EnableHintFile = true
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Create fresh database for each iteration
+		iterDir := fmt.Sprintf("%s/iter%d", tmpDir, i)
+		opts.Dir = iterDir
+
+		db, err := Open(opts)
+		if err != nil {
+			b.Fatalf("Failed to open database: %v", err)
+		}
+
+		bucket := "bucket"
+		txCreateBucket(&testing.T{}, db, DataStructureBTree, bucket, nil)
+
+		// Add data and delete some to trigger merge
+		for j := 0; j < 2000; j++ {
+			txPut(&testing.T{}, db, bucket, GetTestBytes(j), GetTestBytes(j), Persistent, nil, nil)
+		}
+
+		for j := 0; j < 500; j++ {
+			txDel(&testing.T{}, db, bucket, GetTestBytes(j), nil)
+		}
+
+		// Perform merge with hint file creation
+		b.StopTimer()
+		start := time.Now()
+		b.StartTimer()
+
+		err = db.Merge()
+		if err != nil {
+			b.Fatalf("Failed to merge: %v", err)
+		}
+
+		b.StopTimer()
+		mergeTime := time.Since(start)
+		b.ReportMetric(float64(mergeTime.Nanoseconds())/1e6, "ms")
+		b.StartTimer()
+
+		err = db.Close()
+		if err != nil {
+			b.Fatalf("Failed to close database: %v", err)
+		}
+	}
+}
+
+// BenchmarkMergeWithoutHintFile benchmarks merge operation without hint files enabled
+func BenchmarkMergeWithoutHintFile(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-merge-no-hint")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	opts := DefaultOptions
+	opts.Dir = tmpDir
+	opts.SegmentSize = 64 * KB
+	opts.EnableHintFile = false
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Create fresh database for each iteration
+		iterDir := fmt.Sprintf("%s/iter%d", tmpDir, i)
+		opts.Dir = iterDir
+
+		db, err := Open(opts)
+		if err != nil {
+			b.Fatalf("Failed to open database: %v", err)
+		}
+
+		bucket := "bucket"
+		txCreateBucket(&testing.T{}, db, DataStructureBTree, bucket, nil)
+
+		// Add data and delete some to trigger merge
+		for j := 0; j < 2000; j++ {
+			txPut(&testing.T{}, db, bucket, GetTestBytes(j), GetTestBytes(j), Persistent, nil, nil)
+		}
+
+		for j := 0; j < 500; j++ {
+			txDel(&testing.T{}, db, bucket, GetTestBytes(j), nil)
+		}
+
+		// Perform merge without hint file creation
+		b.StopTimer()
+		start := time.Now()
+		b.StartTimer()
+
+		err = db.Merge()
+		if err != nil {
+			b.Fatalf("Failed to merge: %v", err)
+		}
+
+		b.StopTimer()
+		mergeTime := time.Since(start)
+		b.ReportMetric(float64(mergeTime.Nanoseconds())/1e6, "ms")
+		b.StartTimer()
+
+		err = db.Close()
+		if err != nil {
+			b.Fatalf("Failed to close database: %v", err)
+		}
+	}
+}
+
+// BenchmarkHintFileLoad benchmarks loading hint files during database startup
+func BenchmarkHintFileLoad(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-bench-load")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	opts := DefaultOptions
+	opts.Dir = tmpDir
+	opts.SegmentSize = 64 * KB
+	opts.EnableHintFile = true
+
+	// Create database with hint files
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Failed to open database: %v", err)
+	}
+
+	bucket := "bucket"
+	txCreateBucket(&testing.T{}, db, DataStructureBTree, bucket, nil)
+
+	// Add enough data to create multiple files
+	for i := 0; i < 10000; i++ {
+		txPut(&testing.T{}, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	// Perform merge to create hint files
+	err = db.Merge()
+	if err != nil {
+		b.Fatalf("Failed to merge: %v", err)
+	}
+
+	err = db.Close()
+	if err != nil {
+		b.Fatalf("Failed to close database: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		db, err := Open(opts)
+		if err != nil {
+			b.Fatalf("Failed to open database: %v", err)
+		}
+
+		// Just open and close to measure hint file loading time
+		err = db.Close()
+		if err != nil {
+			b.Fatalf("Failed to close database: %v", err)
+		}
+	}
+}

--- a/hintfile_integration_test.go
+++ b/hintfile_integration_test.go
@@ -15,6 +15,7 @@
 package nutsdb
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -25,68 +26,543 @@ import (
 // TestHintFileIntegration_WriteMergeRestartVerify tests the complete workflow:
 // Write data -> Merge -> Restart -> Verify data integrity
 func TestHintFileIntegration_WriteMergeRestartVerify(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = 64 * KB
-	opts.Dir = "/tmp/test-hintfile-integration/"
-	opts.EnableHintFile = true
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = 64 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-integration-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
 
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
-		opts.EntryIdxMode = idxMode
+			// Step 1: Create database and write data
+			db, err := Open(opts)
+			require.NoError(t, err)
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
-		// Step 1: Create database and write data
+			// Write a significant amount of data to trigger merge
+			n := 2000
+			for i := 0; i < n; i++ {
+				txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+			}
+
+			// Delete some data to create dirty entries
+			for i := 0; i < n/4; i++ {
+				txDel(t, db, bucket, GetTestBytes(i), nil)
+			}
+
+			// Verify data before merge
+			for i := n / 4; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+			for i := 0; i < n/4; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Step 2: Perform merge to create hint files
+			require.NoError(t, db.Merge())
+
+			// Verify hint files are created for all merged files
+			sets := collectMergeFileSets(t, opts.Dir)
+			idsToCheck := dataFileIDsForMode(mode, sets)
+			require.Greater(t, len(idsToCheck), 0)
+
+			for _, fid := range idsToCheck {
+				hintPath := getHintPath(fid, opts.Dir)
+				_, err = os.Stat(hintPath)
+				require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
+			}
+
+			// Step 3: Close database
+			require.NoError(t, db.Close())
+
+			// Step 4: Restart database (should use hint files for fast recovery)
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			// Step 5: Verify all data is correctly recovered
+			for i := n / 4; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+			for i := 0; i < n/4; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Verify record count
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(3*n/4), dbCnt)
+
+			require.NoError(t, db.Close())
+		}
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_EnableDisableToggle tests enabling and disabling hint files
+func TestHintFileIntegration_EnableDisableToggle(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = 64 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-toggle-%s", mode.name)
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		// Test with hint files enabled
+		opts.EnableHintFile = true
+
 		db, err := Open(opts)
 		require.NoError(t, err)
 		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
-		// Write a significant amount of data to trigger merge
+		// Write enough data to generate at least 2 data files (for merge to work)
 		n := 2000
 		for i := 0; i < n; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
 		}
 
-		// Delete some data to create dirty entries
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify hint files are created for all merged files
+		setsEnabled := collectMergeFileSets(t, opts.Dir)
+		firstIDs := dataFileIDsForMode(mode, setsEnabled)
+		require.Greater(t, len(firstIDs), 0)
+
+		for _, fid := range firstIDs {
+			hintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist when EnableHintFile is true for file %d", fid)
+		}
+
+		require.NoError(t, db.Close())
+
+		// Test with hint files disabled
+		opts.EnableHintFile = false
+
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		// Write more data to generate additional files for the second merge
+		for i := n; i < n+1500; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Perform merge (should not create hint files)
+		require.NoError(t, db.Merge())
+
+		setsDisabled := collectMergeFileSets(t, opts.Dir)
+		secondIDs := unionDataFileIDs(setsDisabled)
+		require.Greater(t, len(secondIDs), 0)
+
+		// Check that hint files do not exist for any merged files
+		for _, fid := range secondIDs {
+			newHintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(newHintPath)
+			if err == nil {
+				t.Errorf("New hint file %s should not exist when EnableHintFile is false for file %d", newHintPath, fid)
+			}
+		}
+
+		// Verify old hint files should not exist too
+		for _, fid := range firstIDs {
+			oldHintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(oldHintPath)
+			require.Error(t, err, "Old hint file %s should not exist too", oldHintPath)
+		}
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_MultipleMerges tests multiple merge operations
+func TestHintFileIntegration_MultipleMerges(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = 32 * KB // Smaller segment size to trigger more merges
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-multi-merge-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		db, err := Open(opts)
+		require.NoError(t, err)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		// Perform multiple rounds of write->delete->merge
+		for round := 0; round < 3; round++ {
+			// Write data
+			start := round * 500
+			end := (round + 1) * 500
+			for i := start; i < end; i++ {
+				txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+			}
+
+			// Delete some data
+			for i := start; i < start+100; i++ {
+				txDel(t, db, bucket, GetTestBytes(i), nil)
+			}
+
+			// Perform merge
+			require.NoError(t, db.Merge())
+
+			// Verify hint files are created for all merged files
+			sets := collectMergeFileSets(t, opts.Dir)
+			idsToCheck := dataFileIDsForMode(mode, sets)
+			require.Greater(t, len(idsToCheck), 0)
+
+			// Check that hint files exist for all merged files
+			for _, fid := range idsToCheck {
+				hintPath := getHintPath(fid, opts.Dir)
+				_, err = os.Stat(hintPath)
+				require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
+			}
+		}
+
+		// Verify all data is correct
+		for round := 0; round < 3; round++ {
+			start := round * 500
+			end := (round + 1) * 500
+
+			// Check deleted data
+			for i := start; i < start+100; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check remaining data
+			for i := start + 100; i < end; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+		}
+
+		require.NoError(t, db.Close())
+
+		// Restart and verify again
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		for round := 0; round < 3; round++ {
+			start := round * 500
+			end := (round + 1) * 500
+
+			// Check deleted data
+			for i := start; i < start+100; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check remaining data
+			for i := start + 100; i < end; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+		}
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_MixedDataStructures tests hint files with mixed data structures
+func TestHintFileIntegration_MixedDataStructures(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		opts := DefaultOptions
+		opts.SegmentSize = 64 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-mixed-ds-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		db, err := Open(opts)
+		require.NoError(t, err)
+
+		// Create buckets for different data structures
+		bucketBTree := "bucket_btree"
+		bucketSet := "bucket_set"
+		bucketList := "bucket_list"
+		bucketZSet := "bucket_zset"
+
+		txCreateBucket(t, db, DataStructureBTree, bucketBTree, nil)
+		txCreateBucket(t, db, DataStructureSet, bucketSet, nil)
+		txCreateBucket(t, db, DataStructureList, bucketList, nil)
+		txCreateBucket(t, db, DataStructureSortedSet, bucketZSet, nil)
+
+		// Add data to each structure - increase data size to ensure 2 files are created
+		for i := 0; i < 2000; i++ {
+			txPut(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		setKey := GetTestBytes(0)
+		for i := 0; i < 1000; i++ {
+			txSAdd(t, db, bucketSet, setKey, GetTestBytes(i), nil, nil)
+		}
+
+		listKey := GetTestBytes(0)
+		for i := 0; i < 500; i++ {
+			txPush(t, db, bucketList, listKey, GetTestBytes(i), true, nil, nil)
+		}
+
+		zsetKey := GetTestBytes(0)
+		for i := 0; i < 300; i++ {
+			txZAdd(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil, nil)
+		}
+
+		// Delete some data from each structure
+		for i := 0; i < 500; i++ {
+			txDel(t, db, bucketBTree, GetTestBytes(i), nil)
+		}
+		for i := 0; i < 250; i++ {
+			txSRem(t, db, bucketSet, setKey, GetTestBytes(i), nil)
+		}
+		for i := 0; i < 100; i++ {
+			txPop(t, db, bucketList, listKey, GetTestBytes(i), nil, false)
+		}
+		for i := 0; i < 50; i++ {
+			txZRem(t, db, bucketZSet, zsetKey, GetTestBytes(i), nil)
+		}
+
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify hint files are created for all merged files
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := dataFileIDsForMode(mode, sets)
+		require.GreaterOrEqual(t, len(idsToCheck), 1, "Should have at least 1 data file")
+
+		for _, fid := range idsToCheck {
+			hintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
+		}
+
+		require.NoError(t, db.Close())
+
+		// Restart and verify all data structures
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		// Verify BTree data
+		for i := 500; i < 2000; i++ {
+			txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+		for i := 0; i < 500; i++ {
+			txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		}
+
+		// Verify Set data
+		for i := 250; i < 1000; i++ {
+			txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), true)
+		}
+		for i := 0; i < 250; i++ {
+			txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), false)
+		}
+
+		// Verify List data
+		txLRange(t, db, bucketList, listKey, 0, -1, 400, nil, nil)
+
+		// Verify SortedSet data
+		for i := 50; i < 300; i++ {
+			txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil)
+		}
+		for i := 0; i < 50; i++ {
+			txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), 0, ErrSortedSetMemberNotExist)
+		}
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_CrashRecovery tests database recovery after simulated crashes
+func TestHintFileIntegration_CrashRecovery(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = 64 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-crash-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		// Create database and write data
+		db, err := Open(opts)
+		require.NoError(t, err)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		n := 2000
+		for i := 0; i < n; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Perform merge to create hint files
+		require.NoError(t, db.Merge())
+
+		// Simulate crash by not properly closing the database
+		// (just release resources without calling Close())
+		db.ActiveFile.rwManager.Release()
+		db.fm.close()
+		db.flock.Unlock()
+
+		// Restart database (should handle incomplete shutdown gracefully)
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		// Verify all data is correctly recovered
+		for i := 0; i < n; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+
+		// Verify record count
+		dbCnt, err := db.getRecordCount()
+		require.NoError(t, err)
+		require.Equal(t, int64(n), dbCnt)
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_ConcurrentOperations tests hint files with concurrent operations
+func TestHintFileIntegration_ConcurrentOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping concurrent test in short mode")
+	}
+
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		opts := DefaultOptions
+		opts.SegmentSize = 64 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-concurrent-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		db, err := Open(opts)
+		require.NoError(t, err)
+
+		bucket := "bucket"
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		// Perform concurrent writes
+		done := make(chan bool, 20)
+		for i := 0; i < 20; i++ {
+			go func(id int) {
+				for j := 0; j < 100; j++ {
+					key := GetTestBytes(id*100 + j)
+					value := GetTestBytes(id*100 + j)
+					txPut(t, db, bucket, key, value, Persistent, nil, nil)
+				}
+				done <- true
+			}(i)
+		}
+
+		// Wait for all writes to complete
+		for i := 0; i < 20; i++ {
+			<-done
+		}
+
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify hint files are created for all merged files
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := dataFileIDsForMode(mode, sets)
+		require.Greater(t, len(idsToCheck), 0)
+
+		for _, fid := range idsToCheck {
+			hintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
+		}
+
+		require.NoError(t, db.Close())
+
+		// Restart and verify all data
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		// Verify all data is correctly recovered
+		for i := 0; i < 10; i++ {
+			for j := 0; j < 100; j++ {
+				key := GetTestBytes(i*100 + j)
+				value := GetTestBytes(i*100 + j)
+				txGet(t, db, bucket, key, value, nil)
+			}
+		}
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+// TestHintFileIntegration_LargeDataset tests hint files with large datasets
+func TestHintFileIntegration_LargeDataset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large dataset test in short mode")
+	}
+
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		opts := DefaultOptions
+		opts.SegmentSize = 256 * KB
+		opts.Dir = fmt.Sprintf("/tmp/test-hintfile-large-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		db, err := Open(opts)
+		require.NoError(t, err)
+
+		bucket := "bucket"
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		// Write a large amount of data
+		n := 10000
+		for i := 0; i < n; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Delete some data
 		for i := 0; i < n/4; i++ {
 			txDel(t, db, bucket, GetTestBytes(i), nil)
 		}
 
-		// Verify data before merge
-		for i := n / 4; i < n; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-		for i := 0; i < n/4; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Step 2: Perform merge to create hint files
+		// Perform merge
+		start := time.Now()
 		require.NoError(t, db.Merge())
+		mergeTime := time.Since(start)
+		t.Logf("%s merge completed in %v", mode.name, mergeTime)
 
-		// Verify hint files are created for all merged files
-		_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-		require.Greater(t, len(mergedFileIDs), 0)
+		// Verify hint files are created
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := dataFileIDsForMode(mode, sets)
+		require.Greater(t, len(idsToCheck), 0)
+		hintPath := getHintPath(idsToCheck[len(idsToCheck)-1], opts.Dir)
+		_, err = os.Stat(hintPath)
+		require.NoError(t, err, "Hint file should exist after merge")
 
-		// Check that hint files exist for all merged files
-		for _, fileID := range mergedFileIDs {
-			hintPath := getHintPath(int64(fileID), opts.Dir)
-			_, err = os.Stat(hintPath)
-			require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
-		}
-
-		// Step 3: Close database
 		require.NoError(t, db.Close())
 
-		// Step 4: Restart database (should use hint files for fast recovery)
+		// Restart and verify recovery
+		start = time.Now()
 		db, err = Open(opts)
 		require.NoError(t, err)
+		recoveryTime := time.Since(start)
+		t.Logf("%s recovery completed in %v", mode.name, recoveryTime)
 
-		// Step 5: Verify all data is correctly recovered
-		for i := n / 4; i < n; i++ {
+		// Verify sample data
+		for i := n / 4; i < n/4+100; i++ {
 			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
 		}
-		for i := 0; i < n/4; i++ {
+		for i := 0; i < 100; i++ {
 			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
 		}
 
@@ -97,469 +573,5 @@ func TestHintFileIntegration_WriteMergeRestartVerify(t *testing.T) {
 
 		require.NoError(t, db.Close())
 		removeDir(opts.Dir)
-	}
-}
-
-// TestHintFileIntegration_EnableDisableToggle tests enabling and disabling hint files
-func TestHintFileIntegration_EnableDisableToggle(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = 64 * KB
-	opts.Dir = "/tmp/test-hintfile-toggle"
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	// Test with hint files enabled
-	opts.EnableHintFile = true
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Write enough data to generate at least 2 data files (for merge to work)
-	// Each entry is ~82 bytes, so 2000 entries = ~160KB, which will create 3 files with 64KB segments
-	n := 2000
-	for i := 0; i < n; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify hint files are created for all merged files
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(mergedFileIDs), 0)
-
-	// Check that hint files exist for all merged files
-	for _, fileID := range mergedFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(hintPath)
-		require.NoError(t, err, "Hint file should exist when EnableHintFile is true for file %d", fileID)
-	}
-
-	require.NoError(t, db.Close())
-
-	// Test with hint files disabled
-	opts.EnableHintFile = false
-
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	// Write more data to generate additional files for the second merge
-	// Write 1500 more entries to ensure we have at least 2 files to merge
-	for i := n; i < n+1500; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Perform merge (should not create hint files)
-	require.NoError(t, db.Merge())
-
-	// Verify new hint files are not created for any merged files
-	_, newMergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(newMergedFileIDs), 0)
-
-	// Check that hint files do not exist for any merged files
-	for _, fileID := range newMergedFileIDs {
-		newHintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(newHintPath)
-		if err == nil {
-			t.Errorf("New hint file %s should not exist when EnableHintFile is false for file %d", newHintPath, fileID)
-		}
-	}
-
-	// Verify old hint file should not exist too
-	for _, fileID := range mergedFileIDs {
-		oldHintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(oldHintPath)
-		require.Error(t, err, "Old hint file %s should not exist too", oldHintPath)
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-// TestHintFileIntegration_MultipleMerges tests multiple merge operations
-func TestHintFileIntegration_MultipleMerges(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = 32 * KB // Smaller segment size to trigger more merges
-	opts.Dir = "/tmp/test-hintfile-multi-merge/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Perform multiple rounds of write->delete->merge
-	for round := 0; round < 3; round++ {
-		// Write data
-		start := round * 500
-		end := (round + 1) * 500
-		for i := start; i < end; i++ {
-			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-		}
-
-		// Delete some data
-		for i := start; i < start+100; i++ {
-			txDel(t, db, bucket, GetTestBytes(i), nil)
-		}
-
-		// Perform merge
-		require.NoError(t, db.Merge())
-
-		// Verify hint files are created for all merged files
-		_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-		require.Greater(t, len(mergedFileIDs), 0)
-
-		// Check that hint files exist for all merged files
-		for _, fileID := range mergedFileIDs {
-			hintPath := getHintPath(int64(fileID), opts.Dir)
-			_, err = os.Stat(hintPath)
-			require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
-		}
-	}
-
-	// Verify all data is correct
-	for round := 0; round < 3; round++ {
-		start := round * 500
-		end := (round + 1) * 500
-
-		// Check deleted data
-		for i := start; i < start+100; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Check remaining data
-		for i := start + 100; i < end; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-	}
-
-	require.NoError(t, db.Close())
-
-	// Restart and verify again
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	for round := 0; round < 3; round++ {
-		start := round * 500
-		end := (round + 1) * 500
-
-		// Check deleted data
-		for i := start; i < start+100; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Check remaining data
-		for i := start + 100; i < end; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-// TestHintFileIntegration_MixedDataStructures tests hint files with mixed data structures
-func TestHintFileIntegration_MixedDataStructures(t *testing.T) {
-	opts := DefaultOptions
-	opts.SegmentSize = 64 * KB
-	opts.Dir = "/tmp/test-hintfile-mixed-ds/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-
-	// Create buckets for different data structures
-	bucketBTree := "bucket_btree"
-	bucketSet := "bucket_set"
-	bucketList := "bucket_list"
-	bucketZSet := "bucket_zset"
-
-	txCreateBucket(t, db, DataStructureBTree, bucketBTree, nil)
-	txCreateBucket(t, db, DataStructureSet, bucketSet, nil)
-	txCreateBucket(t, db, DataStructureList, bucketList, nil)
-	txCreateBucket(t, db, DataStructureSortedSet, bucketZSet, nil)
-
-	// Add data to each structure - increase data size to ensure 2 files are created
-	for i := 0; i < 2000; i++ {
-		txPut(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	setKey := GetTestBytes(0)
-	for i := 0; i < 1000; i++ {
-		txSAdd(t, db, bucketSet, setKey, GetTestBytes(i), nil, nil)
-	}
-
-	listKey := GetTestBytes(0)
-	for i := 0; i < 500; i++ {
-		txPush(t, db, bucketList, listKey, GetTestBytes(i), true, nil, nil)
-	}
-
-	zsetKey := GetTestBytes(0)
-	for i := 0; i < 300; i++ {
-		txZAdd(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil, nil)
-	}
-
-	// Delete some data from each structure
-	for i := 0; i < 500; i++ {
-		txDel(t, db, bucketBTree, GetTestBytes(i), nil)
-	}
-	for i := 0; i < 250; i++ {
-		txSRem(t, db, bucketSet, setKey, GetTestBytes(i), nil)
-	}
-	for i := 0; i < 100; i++ {
-		txPop(t, db, bucketList, listKey, GetTestBytes(i), nil, false)
-	}
-	for i := 0; i < 50; i++ {
-		txZRem(t, db, bucketZSet, zsetKey, GetTestBytes(i), nil)
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify hint files are created for all merged files
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.GreaterOrEqual(t, len(mergedFileIDs), 2, "Should have at least 2 files")
-
-	// Check that hint files exist for all merged files
-	for _, fileID := range mergedFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(hintPath)
-		require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
-	}
-
-	require.NoError(t, db.Close())
-
-	// Restart and verify all data structures
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	// Verify BTree data
-	for i := 500; i < 2000; i++ {
-		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), nil)
-	}
-	for i := 0; i < 500; i++ {
-		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-	}
-
-	// Verify Set data
-	for i := 250; i < 1000; i++ {
-		txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), true)
-	}
-	for i := 0; i < 250; i++ {
-		txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), false)
-	}
-
-	// Verify List data
-	txLRange(t, db, bucketList, listKey, 0, -1, 400, nil, nil)
-
-	// Verify SortedSet data
-	for i := 50; i < 300; i++ {
-		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil)
-	}
-	for i := 0; i < 50; i++ {
-		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), 0, ErrSortedSetMemberNotExist)
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-// TestHintFileIntegration_CrashRecovery tests database recovery after simulated crashes
-func TestHintFileIntegration_CrashRecovery(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = 64 * KB
-	opts.Dir = "/tmp/test-hintfile-crash/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	// Create database and write data
-	db, err := Open(opts)
-	require.NoError(t, err)
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	n := 2000
-	for i := 0; i < n; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Perform merge to create hint files
-	require.NoError(t, db.Merge())
-
-	// Simulate crash by not properly closing the database
-	// (just release resources without calling Close())
-	db.ActiveFile.rwManager.Release()
-	db.fm.close()
-	db.flock.Unlock()
-
-	// Restart database (should handle incomplete shutdown gracefully)
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	// Verify all data is correctly recovered
-	for i := 0; i < n; i++ {
-		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-	}
-
-	// Verify record count
-	dbCnt, err := db.getRecordCount()
-	require.NoError(t, err)
-	require.Equal(t, int64(n), dbCnt)
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-// TestHintFileIntegration_ConcurrentOperations tests hint files with concurrent operations
-func TestHintFileIntegration_ConcurrentOperations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping concurrent test in short mode")
-	}
-
-	opts := DefaultOptions
-	opts.SegmentSize = 64 * KB
-	opts.Dir = "/tmp/test-hintfile-concurrent/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-
-	bucket := "bucket"
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Perform concurrent writes
-	done := make(chan bool, 20)
-	for i := 0; i < 20; i++ {
-		go func(id int) {
-			for j := 0; j < 100; j++ {
-				key := GetTestBytes(id*100 + j)
-				value := GetTestBytes(id*100 + j)
-				txPut(t, db, bucket, key, value, Persistent, nil, nil)
-			}
-			done <- true
-		}(i)
-	}
-
-	// Wait for all writes to complete
-	for i := 0; i < 20; i++ {
-		<-done
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify hint files are created for all merged files
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(mergedFileIDs), 0)
-
-	// Check that hint files exist for all merged files
-	for _, fileID := range mergedFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(hintPath)
-		require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
-	}
-
-	require.NoError(t, db.Close())
-
-	// Restart and verify all data
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	// Verify all data is correctly recovered
-	for i := 0; i < 10; i++ {
-		for j := 0; j < 100; j++ {
-			key := GetTestBytes(i*100 + j)
-			value := GetTestBytes(i*100 + j)
-			txGet(t, db, bucket, key, value, nil)
-		}
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-// TestHintFileIntegration_LargeDataset tests hint files with large datasets
-func TestHintFileIntegration_LargeDataset(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping large dataset test in short mode")
-	}
-
-	opts := DefaultOptions
-	opts.SegmentSize = 256 * KB
-	opts.Dir = "/tmp/test-hintfile-large/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-
-	bucket := "bucket"
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Write a large amount of data
-	n := 10000
-	for i := 0; i < n; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Delete some data
-	for i := 0; i < n/4; i++ {
-		txDel(t, db, bucket, GetTestBytes(i), nil)
-	}
-
-	// Perform merge
-	start := time.Now()
-	require.NoError(t, db.Merge())
-	mergeTime := time.Since(start)
-	t.Logf("Merge completed in %v", mergeTime)
-
-	// Verify hint files are created
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(mergedFileIDs), 0)
-
-	maxFileID := mergedFileIDs[len(mergedFileIDs)-1]
-	hintPath := getHintPath(int64(maxFileID), opts.Dir)
-	_, err = os.Stat(hintPath)
-	require.NoError(t, err, "Hint file should exist after merge")
-
-	require.NoError(t, db.Close())
-
-	// Restart and verify recovery
-	start = time.Now()
-	db, err = Open(opts)
-	require.NoError(t, err)
-	recoveryTime := time.Since(start)
-	t.Logf("Recovery completed in %v", recoveryTime)
-
-	// Verify sample data
-	for i := n / 4; i < n/4+100; i++ {
-		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-	}
-	for i := 0; i < 100; i++ {
-		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-	}
-
-	// Verify record count
-	dbCnt, err := db.getRecordCount()
-	require.NoError(t, err)
-	require.Equal(t, int64(3*n/4), dbCnt)
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
+	})
 }

--- a/hintfile_integration_test.go
+++ b/hintfile_integration_test.go
@@ -1,0 +1,565 @@
+// Copyright 2023 The nutsdb Author. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nutsdb
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHintFileIntegration_WriteMergeRestartVerify tests the complete workflow:
+// Write data -> Merge -> Restart -> Verify data integrity
+func TestHintFileIntegration_WriteMergeRestartVerify(t *testing.T) {
+	bucket := "bucket"
+	opts := DefaultOptions
+	opts.SegmentSize = 64 * KB
+	opts.Dir = "/tmp/test-hintfile-integration/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+		opts.EntryIdxMode = idxMode
+
+		// Step 1: Create database and write data
+		db, err := Open(opts)
+		require.NoError(t, err)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		// Write a significant amount of data to trigger merge
+		n := 2000
+		for i := 0; i < n; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Delete some data to create dirty entries
+		for i := 0; i < n/4; i++ {
+			txDel(t, db, bucket, GetTestBytes(i), nil)
+		}
+
+		// Verify data before merge
+		for i := n / 4; i < n; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+		for i := 0; i < n/4; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		}
+
+		// Step 2: Perform merge to create hint files
+		require.NoError(t, db.Merge())
+
+		// Verify hint files are created for all merged files
+		_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+		require.Greater(t, len(mergedFileIDs), 0)
+
+		// Check that hint files exist for all merged files
+		for _, fileID := range mergedFileIDs {
+			hintPath := getHintPath(int64(fileID), opts.Dir)
+			_, err = os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
+		}
+
+		// Step 3: Close database
+		require.NoError(t, db.Close())
+
+		// Step 4: Restart database (should use hint files for fast recovery)
+		db, err = Open(opts)
+		require.NoError(t, err)
+
+		// Step 5: Verify all data is correctly recovered
+		for i := n / 4; i < n; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+		for i := 0; i < n/4; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		}
+
+		// Verify record count
+		dbCnt, err := db.getRecordCount()
+		require.NoError(t, err)
+		require.Equal(t, int64(3*n/4), dbCnt)
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	}
+}
+
+// TestHintFileIntegration_EnableDisableToggle tests enabling and disabling hint files
+func TestHintFileIntegration_EnableDisableToggle(t *testing.T) {
+	bucket := "bucket"
+	opts := DefaultOptions
+	opts.SegmentSize = 64 * KB
+	opts.Dir = "/tmp/test-hintfile-toggle"
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	// Test with hint files enabled
+	opts.EnableHintFile = true
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+	// Write enough data to generate at least 2 data files (for merge to work)
+	// Each entry is ~82 bytes, so 2000 entries = ~160KB, which will create 3 files with 64KB segments
+	n := 2000
+	for i := 0; i < n; i++ {
+		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	// Perform merge
+	require.NoError(t, db.Merge())
+
+	// Verify hint files are created for all merged files
+	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+	require.Greater(t, len(mergedFileIDs), 0)
+
+	// Check that hint files exist for all merged files
+	for _, fileID := range mergedFileIDs {
+		hintPath := getHintPath(int64(fileID), opts.Dir)
+		_, err = os.Stat(hintPath)
+		require.NoError(t, err, "Hint file should exist when EnableHintFile is true for file %d", fileID)
+	}
+
+	require.NoError(t, db.Close())
+
+	// Test with hint files disabled
+	opts.EnableHintFile = false
+
+	db, err = Open(opts)
+	require.NoError(t, err)
+
+	// Write more data to generate additional files for the second merge
+	// Write 1500 more entries to ensure we have at least 2 files to merge
+	for i := n; i < n+1500; i++ {
+		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	// Perform merge (should not create hint files)
+	require.NoError(t, db.Merge())
+
+	// Verify new hint files are not created for any merged files
+	_, newMergedFileIDs := db.getMaxFileIDAndFileIDs()
+	require.Greater(t, len(newMergedFileIDs), 0)
+
+	// Check that hint files do not exist for any merged files
+	for _, fileID := range newMergedFileIDs {
+		newHintPath := getHintPath(int64(fileID), opts.Dir)
+		_, err = os.Stat(newHintPath)
+		if err == nil {
+			t.Errorf("New hint file %s should not exist when EnableHintFile is false for file %d", newHintPath, fileID)
+		}
+	}
+
+	// Verify old hint file should not exist too
+	for _, fileID := range mergedFileIDs {
+		oldHintPath := getHintPath(int64(fileID), opts.Dir)
+		_, err = os.Stat(oldHintPath)
+		require.Error(t, err, "Old hint file %s should not exist too", oldHintPath)
+	}
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}
+
+// TestHintFileIntegration_MultipleMerges tests multiple merge operations
+func TestHintFileIntegration_MultipleMerges(t *testing.T) {
+	bucket := "bucket"
+	opts := DefaultOptions
+	opts.SegmentSize = 32 * KB // Smaller segment size to trigger more merges
+	opts.Dir = "/tmp/test-hintfile-multi-merge/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+	// Perform multiple rounds of write->delete->merge
+	for round := 0; round < 3; round++ {
+		// Write data
+		start := round * 500
+		end := (round + 1) * 500
+		for i := start; i < end; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Delete some data
+		for i := start; i < start+100; i++ {
+			txDel(t, db, bucket, GetTestBytes(i), nil)
+		}
+
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify hint files are created for all merged files
+		_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+		require.Greater(t, len(mergedFileIDs), 0)
+
+		// Check that hint files exist for all merged files
+		for _, fileID := range mergedFileIDs {
+			hintPath := getHintPath(int64(fileID), opts.Dir)
+			_, err = os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
+		}
+	}
+
+	// Verify all data is correct
+	for round := 0; round < 3; round++ {
+		start := round * 500
+		end := (round + 1) * 500
+
+		// Check deleted data
+		for i := start; i < start+100; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		}
+
+		// Check remaining data
+		for i := start + 100; i < end; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+	}
+
+	require.NoError(t, db.Close())
+
+	// Restart and verify again
+	db, err = Open(opts)
+	require.NoError(t, err)
+
+	for round := 0; round < 3; round++ {
+		start := round * 500
+		end := (round + 1) * 500
+
+		// Check deleted data
+		for i := start; i < start+100; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		}
+
+		// Check remaining data
+		for i := start + 100; i < end; i++ {
+			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+	}
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}
+
+// TestHintFileIntegration_MixedDataStructures tests hint files with mixed data structures
+func TestHintFileIntegration_MixedDataStructures(t *testing.T) {
+	opts := DefaultOptions
+	opts.SegmentSize = 64 * KB
+	opts.Dir = "/tmp/test-hintfile-mixed-ds/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+
+	// Create buckets for different data structures
+	bucketBTree := "bucket_btree"
+	bucketSet := "bucket_set"
+	bucketList := "bucket_list"
+	bucketZSet := "bucket_zset"
+
+	txCreateBucket(t, db, DataStructureBTree, bucketBTree, nil)
+	txCreateBucket(t, db, DataStructureSet, bucketSet, nil)
+	txCreateBucket(t, db, DataStructureList, bucketList, nil)
+	txCreateBucket(t, db, DataStructureSortedSet, bucketZSet, nil)
+
+	// Add data to each structure - increase data size to ensure 2 files are created
+	for i := 0; i < 2000; i++ {
+		txPut(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	setKey := GetTestBytes(0)
+	for i := 0; i < 1000; i++ {
+		txSAdd(t, db, bucketSet, setKey, GetTestBytes(i), nil, nil)
+	}
+
+	listKey := GetTestBytes(0)
+	for i := 0; i < 500; i++ {
+		txPush(t, db, bucketList, listKey, GetTestBytes(i), true, nil, nil)
+	}
+
+	zsetKey := GetTestBytes(0)
+	for i := 0; i < 300; i++ {
+		txZAdd(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil, nil)
+	}
+
+	// Delete some data from each structure
+	for i := 0; i < 500; i++ {
+		txDel(t, db, bucketBTree, GetTestBytes(i), nil)
+	}
+	for i := 0; i < 250; i++ {
+		txSRem(t, db, bucketSet, setKey, GetTestBytes(i), nil)
+	}
+	for i := 0; i < 100; i++ {
+		txPop(t, db, bucketList, listKey, GetTestBytes(i), nil, false)
+	}
+	for i := 0; i < 50; i++ {
+		txZRem(t, db, bucketZSet, zsetKey, GetTestBytes(i), nil)
+	}
+
+	// Perform merge
+	require.NoError(t, db.Merge())
+
+	// Verify hint files are created for all merged files
+	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+	require.GreaterOrEqual(t, len(mergedFileIDs), 2, "Should have at least 2 files")
+
+	// Check that hint files exist for all merged files
+	for _, fileID := range mergedFileIDs {
+		hintPath := getHintPath(int64(fileID), opts.Dir)
+		_, err = os.Stat(hintPath)
+		require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
+	}
+
+	require.NoError(t, db.Close())
+
+	// Restart and verify all data structures
+	db, err = Open(opts)
+	require.NoError(t, err)
+
+	// Verify BTree data
+	for i := 500; i < 2000; i++ {
+		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), nil)
+	}
+	for i := 0; i < 500; i++ {
+		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+	}
+
+	// Verify Set data
+	for i := 250; i < 1000; i++ {
+		txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), true)
+	}
+	for i := 0; i < 250; i++ {
+		txSIsMember(t, db, bucketSet, setKey, GetTestBytes(i), false)
+	}
+
+	// Verify List data
+	txLRange(t, db, bucketList, listKey, 0, -1, 400, nil, nil)
+
+	// Verify SortedSet data
+	for i := 50; i < 300; i++ {
+		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil)
+	}
+	for i := 0; i < 50; i++ {
+		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), 0, ErrSortedSetMemberNotExist)
+	}
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}
+
+// TestHintFileIntegration_CrashRecovery tests database recovery after simulated crashes
+func TestHintFileIntegration_CrashRecovery(t *testing.T) {
+	bucket := "bucket"
+	opts := DefaultOptions
+	opts.SegmentSize = 64 * KB
+	opts.Dir = "/tmp/test-hintfile-crash/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	// Create database and write data
+	db, err := Open(opts)
+	require.NoError(t, err)
+	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+	n := 2000
+	for i := 0; i < n; i++ {
+		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	// Perform merge to create hint files
+	require.NoError(t, db.Merge())
+
+	// Simulate crash by not properly closing the database
+	// (just release resources without calling Close())
+	db.ActiveFile.rwManager.Release()
+	db.fm.close()
+	db.flock.Unlock()
+
+	// Restart database (should handle incomplete shutdown gracefully)
+	db, err = Open(opts)
+	require.NoError(t, err)
+
+	// Verify all data is correctly recovered
+	for i := 0; i < n; i++ {
+		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+	}
+
+	// Verify record count
+	dbCnt, err := db.getRecordCount()
+	require.NoError(t, err)
+	require.Equal(t, int64(n), dbCnt)
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}
+
+// TestHintFileIntegration_ConcurrentOperations tests hint files with concurrent operations
+func TestHintFileIntegration_ConcurrentOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping concurrent test in short mode")
+	}
+
+	opts := DefaultOptions
+	opts.SegmentSize = 64 * KB
+	opts.Dir = "/tmp/test-hintfile-concurrent/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+
+	bucket := "bucket"
+	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+	// Perform concurrent writes
+	done := make(chan bool, 20)
+	for i := 0; i < 20; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				key := GetTestBytes(id*100 + j)
+				value := GetTestBytes(id*100 + j)
+				txPut(t, db, bucket, key, value, Persistent, nil, nil)
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all writes to complete
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	// Perform merge
+	require.NoError(t, db.Merge())
+
+	// Verify hint files are created for all merged files
+	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+	require.Greater(t, len(mergedFileIDs), 0)
+
+	// Check that hint files exist for all merged files
+	for _, fileID := range mergedFileIDs {
+		hintPath := getHintPath(int64(fileID), opts.Dir)
+		_, err = os.Stat(hintPath)
+		require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
+	}
+
+	require.NoError(t, db.Close())
+
+	// Restart and verify all data
+	db, err = Open(opts)
+	require.NoError(t, err)
+
+	// Verify all data is correctly recovered
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 100; j++ {
+			key := GetTestBytes(i*100 + j)
+			value := GetTestBytes(i*100 + j)
+			txGet(t, db, bucket, key, value, nil)
+		}
+	}
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}
+
+// TestHintFileIntegration_LargeDataset tests hint files with large datasets
+func TestHintFileIntegration_LargeDataset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large dataset test in short mode")
+	}
+
+	opts := DefaultOptions
+	opts.SegmentSize = 256 * KB
+	opts.Dir = "/tmp/test-hintfile-large/"
+	opts.EnableHintFile = true
+
+	// Clean the test directory at the start
+	removeDir(opts.Dir)
+
+	db, err := Open(opts)
+	require.NoError(t, err)
+
+	bucket := "bucket"
+	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+	// Write a large amount of data
+	n := 10000
+	for i := 0; i < n; i++ {
+		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+	}
+
+	// Delete some data
+	for i := 0; i < n/4; i++ {
+		txDel(t, db, bucket, GetTestBytes(i), nil)
+	}
+
+	// Perform merge
+	start := time.Now()
+	require.NoError(t, db.Merge())
+	mergeTime := time.Since(start)
+	t.Logf("Merge completed in %v", mergeTime)
+
+	// Verify hint files are created
+	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
+	require.Greater(t, len(mergedFileIDs), 0)
+
+	maxFileID := mergedFileIDs[len(mergedFileIDs)-1]
+	hintPath := getHintPath(int64(maxFileID), opts.Dir)
+	_, err = os.Stat(hintPath)
+	require.NoError(t, err, "Hint file should exist after merge")
+
+	require.NoError(t, db.Close())
+
+	// Restart and verify recovery
+	start = time.Now()
+	db, err = Open(opts)
+	require.NoError(t, err)
+	recoveryTime := time.Since(start)
+	t.Logf("Recovery completed in %v", recoveryTime)
+
+	// Verify sample data
+	for i := n / 4; i < n/4+100; i++ {
+		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+	}
+	for i := 0; i < 100; i++ {
+		txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+	}
+
+	// Verify record count
+	dbCnt, err := db.getRecordCount()
+	require.NoError(t, err)
+	require.Equal(t, int64(3*n/4), dbCnt)
+
+	require.NoError(t, db.Close())
+	removeDir(opts.Dir)
+}

--- a/hintfile_test.go
+++ b/hintfile_test.go
@@ -1,0 +1,564 @@
+package nutsdb
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHintFileBasicOperations(t *testing.T) {
+	// Test HintEntry encoding and decoding
+	entry := &HintEntry{
+		BucketId:  1,
+		KeySize:   3,
+		ValueSize: 5,
+		Timestamp: 1234567890,
+		TTL:       3600,
+		Flag:      DataSetFlag,
+		Status:    Committed,
+		Ds:        DataStructureBTree,
+		DataPos:   100,
+		FileID:    1,
+		Key:       []byte("key"),
+	}
+
+	// Test encoding
+	encoded := entry.Encode()
+	if len(encoded) == 0 {
+		t.Fatal("Failed to encode hint entry")
+	}
+
+	// Test decoding
+	decoded := &HintEntry{}
+	err := decoded.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Failed to decode hint entry: %v", err)
+	}
+
+	// Verify decoded values
+	if decoded.BucketId != entry.BucketId {
+		t.Errorf("Expected BucketId %d, got %d", entry.BucketId, decoded.BucketId)
+	}
+	if decoded.KeySize != entry.KeySize {
+		t.Errorf("Expected KeySize %d, got %d", entry.KeySize, decoded.KeySize)
+	}
+	if decoded.ValueSize != entry.ValueSize {
+		t.Errorf("Expected ValueSize %d, got %d", entry.ValueSize, decoded.ValueSize)
+	}
+	if decoded.Timestamp != entry.Timestamp {
+		t.Errorf("Expected Timestamp %d, got %d", entry.Timestamp, decoded.Timestamp)
+	}
+	if decoded.TTL != entry.TTL {
+		t.Errorf("Expected TTL %d, got %d", entry.TTL, decoded.TTL)
+	}
+	if decoded.Flag != entry.Flag {
+		t.Errorf("Expected Flag %d, got %d", entry.Flag, decoded.Flag)
+	}
+	if decoded.Status != entry.Status {
+		t.Errorf("Expected Status %d, got %d", entry.Status, decoded.Status)
+	}
+	if decoded.Ds != entry.Ds {
+		t.Errorf("Expected Ds %d, got %d", entry.Ds, decoded.Ds)
+	}
+	if decoded.DataPos != entry.DataPos {
+		t.Errorf("Expected DataPos %d, got %d", entry.DataPos, decoded.DataPos)
+	}
+	if decoded.FileID != entry.FileID {
+		t.Errorf("Expected FileID %d, got %d", entry.FileID, decoded.FileID)
+	}
+	if string(decoded.Key) != string(entry.Key) {
+		t.Errorf("Expected Key %s, got %s", string(entry.Key), string(decoded.Key))
+	}
+}
+
+func TestHintEntrySize(t *testing.T) {
+	entry := &HintEntry{
+		BucketId:  1,
+		KeySize:   3,
+		ValueSize: 5,
+		Timestamp: 1234567890,
+		TTL:       3600,
+		Flag:      DataSetFlag,
+		Status:    Committed,
+		Ds:        DataStructureBTree,
+		DataPos:   100,
+		FileID:    1,
+		Key:       []byte("key"),
+	}
+
+	expectedSize := entry.Size()
+	encoded := entry.Encode()
+	actualSize := int64(len(encoded))
+
+	if expectedSize != actualSize {
+		t.Errorf("Expected size %d, got %d", expectedSize, actualSize)
+	}
+}
+
+func TestHintEntryEncodeDecodeEdgeCases(t *testing.T) {
+	testCases := []struct {
+		name  string
+		entry *HintEntry
+	}{
+		{
+			name: "Empty key",
+			entry: &HintEntry{
+				BucketId:  1,
+				KeySize:   0,
+				ValueSize: 5,
+				Timestamp: 1234567890,
+				TTL:       3600,
+				Flag:      DataSetFlag,
+				Status:    Committed,
+				Ds:        DataStructureBTree,
+				DataPos:   100,
+				FileID:    1,
+				Key:       []byte(""),
+			},
+		},
+		{
+			name: "Large key",
+			entry: &HintEntry{
+				BucketId:  1,
+				KeySize:   1000,
+				ValueSize: 5,
+				Timestamp: 1234567890,
+				TTL:       3600,
+				Flag:      DataSetFlag,
+				Status:    Committed,
+				Ds:        DataStructureBTree,
+				DataPos:   100,
+				FileID:    1,
+				Key:       make([]byte, 1000),
+			},
+		},
+		{
+			name: "Zero TTL",
+			entry: &HintEntry{
+				BucketId:  1,
+				KeySize:   3,
+				ValueSize: 5,
+				Timestamp: 1234567890,
+				TTL:       0,
+				Flag:      DataSetFlag,
+				Status:    Committed,
+				Ds:        DataStructureBTree,
+				DataPos:   100,
+				FileID:    1,
+				Key:       []byte("key"),
+			},
+		},
+		{
+			name: "Different data structures",
+			entry: &HintEntry{
+				BucketId:  1,
+				KeySize:   3,
+				ValueSize: 5,
+				Timestamp: 1234567890,
+				TTL:       3600,
+				Flag:      DataLPushFlag,
+				Status:    Committed,
+				Ds:        DataStructureList,
+				DataPos:   100,
+				FileID:    1,
+				Key:       []byte("key"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := tc.entry.Encode()
+			if len(encoded) == 0 {
+				t.Fatal("Failed to encode hint entry")
+			}
+
+			decoded := &HintEntry{}
+			err := decoded.Decode(encoded)
+			if err != nil {
+				t.Fatalf("Failed to decode hint entry: %v", err)
+			}
+
+			// Verify key values match
+			if decoded.BucketId != tc.entry.BucketId {
+				t.Errorf("Expected BucketId %d, got %d", tc.entry.BucketId, decoded.BucketId)
+			}
+			if decoded.KeySize != tc.entry.KeySize {
+				t.Errorf("Expected KeySize %d, got %d", tc.entry.KeySize, decoded.KeySize)
+			}
+			if !stringEqual(decoded.Key, tc.entry.Key) {
+				t.Errorf("Expected Key %s, got %s", string(tc.entry.Key), string(decoded.Key))
+			}
+		})
+	}
+}
+
+func stringEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestHintFileWriterReader(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hintPath := filepath.Join(tmpDir, "1.hint")
+
+	// Test writing
+	writer := &HintFileWriter{}
+	err = writer.Create(hintPath)
+	if err != nil {
+		t.Fatalf("Failed to create hint file: %v", err)
+	}
+
+	// Write some entries
+	entries := []*HintEntry{
+		{
+			BucketId:  1,
+			KeySize:   uint32(len([]byte("key1"))),
+			ValueSize: 5,
+			Timestamp: 1234567890,
+			TTL:       3600,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureBTree,
+			DataPos:   100,
+			FileID:    1,
+			Key:       []byte("key1"),
+		},
+		{
+			BucketId:  2,
+			KeySize:   uint32(len([]byte("key2"))),
+			ValueSize: 7,
+			Timestamp: 1234567891,
+			TTL:       7200,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureSet,
+			DataPos:   200,
+			FileID:    1,
+			Key:       []byte("key2"),
+		},
+	}
+
+	for _, entry := range entries {
+		err = writer.Write(entry)
+		if err != nil {
+			t.Fatalf("Failed to write hint entry: %v", err)
+		}
+	}
+
+	err = writer.Sync()
+	if err != nil {
+		t.Fatalf("Failed to sync hint file: %v", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatalf("Failed to close hint file: %v", err)
+	}
+
+	// Test reading
+	reader := &HintFileReader{}
+	err = reader.Open(hintPath)
+	if err != nil {
+		t.Fatalf("Failed to open hint file: %v", err)
+	}
+	defer reader.Close()
+
+	// Read and verify entries
+	for i, expectedEntry := range entries {
+		entry, err := reader.Read()
+		if err != nil {
+			t.Fatalf("Failed to read hint entry %d: %v", i, err)
+		}
+
+		if entry.BucketId != expectedEntry.BucketId {
+			t.Errorf("Entry %d: Expected BucketId %d, got %d", i, expectedEntry.BucketId, entry.BucketId)
+		}
+		if string(entry.Key) != string(expectedEntry.Key) {
+			t.Errorf("Entry %d: Expected Key %s, got %s", i, string(expectedEntry.Key), string(entry.Key))
+		}
+		if entry.DataPos != expectedEntry.DataPos {
+			t.Errorf("Entry %d: Expected DataPos %d, got %d", i, expectedEntry.DataPos, entry.DataPos)
+		}
+
+		t.Logf("Successfully read entry %d: BucketId=%d, Key=%s, DataPos=%d",
+			i, entry.BucketId, string(entry.Key), entry.DataPos)
+	}
+
+	// Should get EOF at the end
+	_, err = reader.Read()
+	if err != nil {
+		if err != io.EOF && err != ErrIndexOutOfBound && err != ErrEntryZero && err != ErrHeaderSizeOutOfBounds {
+			t.Fatalf("Expected EOF or similar error, got: %v", err)
+		}
+	}
+}
+
+func TestHintFileWriterErrorHandling(t *testing.T) {
+	t.Run("Write nil entry", func(t *testing.T) {
+		writer := &HintFileWriter{}
+		err := writer.Write(nil)
+		if err != ErrHintFileEntryInvalid {
+			t.Errorf("Expected ErrHintFileEntryInvalid, got %v", err)
+		}
+	})
+
+	t.Run("Create file in non-existent directory", func(t *testing.T) {
+		writer := &HintFileWriter{}
+		err := writer.Create("/non/existent/path/test.hint")
+		if err == nil {
+			t.Error("Expected error when creating file in non-existent directory")
+		}
+	})
+
+	t.Run("Sync without file", func(t *testing.T) {
+		writer := &HintFileWriter{}
+		err := writer.Sync()
+		if err != nil {
+			t.Errorf("Unexpected error when syncing without file: %v", err)
+		}
+	})
+
+	t.Run("Close without file", func(t *testing.T) {
+		writer := &HintFileWriter{}
+		err := writer.Close()
+		if err != nil {
+			t.Errorf("Unexpected error when closing without file: %v", err)
+		}
+	})
+}
+
+func TestHintFileReaderErrorHandling(t *testing.T) {
+	t.Run("Open non-existent file", func(t *testing.T) {
+		reader := &HintFileReader{}
+		err := reader.Open("/non/existent/path/test.hint")
+		if err == nil {
+			t.Error("Expected error when opening non-existent file")
+		}
+	})
+
+	t.Run("Read without opening file", func(t *testing.T) {
+		reader := &HintFileReader{}
+		_, err := reader.Read()
+		if err != ErrHintFileEntryInvalid {
+			t.Errorf("Expected ErrHintFileEntryInvalid, got %v", err)
+		}
+	})
+
+	t.Run("Read corrupted file", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "hintfile-test")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		corruptedPath := filepath.Join(tmpDir, "corrupted.hint")
+		// Create a corrupted file with invalid data
+		err = os.WriteFile(corruptedPath, []byte{0xFF, 0xFF, 0xFF}, 0644)
+		if err != nil {
+			t.Fatalf("Failed to create corrupted file: %v", err)
+		}
+
+		reader := &HintFileReader{}
+		err = reader.Open(corruptedPath)
+		if err != nil {
+			t.Fatalf("Failed to open corrupted file: %v", err)
+		}
+		defer reader.Close()
+
+		_, err = reader.Read()
+		if err == nil {
+			t.Error("Expected error when reading corrupted file")
+		}
+	})
+
+	t.Run("Read empty file", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "hintfile-test")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		emptyPath := filepath.Join(tmpDir, "empty.hint")
+		// Create an empty file
+		err = os.WriteFile(emptyPath, []byte{}, 0644)
+		if err != nil {
+			t.Fatalf("Failed to create empty file: %v", err)
+		}
+
+		reader := &HintFileReader{}
+		err = reader.Open(emptyPath)
+		if err != nil {
+			t.Fatalf("Failed to open empty file: %v", err)
+		}
+		defer reader.Close()
+
+		_, err = reader.Read()
+		if err != io.EOF {
+			t.Errorf("Expected EOF, got %v", err)
+		}
+	})
+}
+
+func TestHintEntryDecodeInvalidData(t *testing.T) {
+	testCases := []struct {
+		name        string
+		data        []byte
+		expectedErr error
+	}{
+		{
+			name:        "Empty data",
+			data:        []byte{},
+			expectedErr: ErrHintFileEntryInvalid,
+		},
+		{
+			name:        "Incomplete header",
+			data:        []byte{0x01}, // Only bucket ID, missing other fields
+			expectedErr: ErrHintFileCorrupted,
+		},
+		{
+			name:        "Invalid varint",
+			data:        []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // Invalid varint
+			expectedErr: ErrHintFileCorrupted,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := &HintEntry{}
+			err := entry.Decode(tc.data)
+			if err != tc.expectedErr {
+				t.Errorf("Expected error %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestHintFilePartialRead(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hintfile-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hintPath := filepath.Join(tmpDir, "partial.hint")
+
+	// Create a hint file with multiple entries
+	writer := &HintFileWriter{}
+	err = writer.Create(hintPath)
+	if err != nil {
+		t.Fatalf("Failed to create hint file: %v", err)
+	}
+
+	entries := []*HintEntry{
+		{
+			BucketId:  1,
+			KeySize:   3,
+			ValueSize: 5,
+			Timestamp: 1234567890,
+			TTL:       3600,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureBTree,
+			DataPos:   100,
+			FileID:    1,
+			Key:       []byte("key1"),
+		},
+		{
+			BucketId:  2,
+			KeySize:   3,
+			ValueSize: 5,
+			Timestamp: 1234567891,
+			TTL:       3600,
+			Flag:      DataSetFlag,
+			Status:    Committed,
+			Ds:        DataStructureBTree,
+			DataPos:   200,
+			FileID:    1,
+			Key:       []byte("key2"),
+		},
+	}
+
+	for _, entry := range entries {
+		err = writer.Write(entry)
+		if err != nil {
+			t.Fatalf("Failed to write hint entry: %v", err)
+		}
+	}
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatalf("Failed to close hint file: %v", err)
+	}
+
+	// Read only the first entry
+	reader := &HintFileReader{}
+	err = reader.Open(hintPath)
+	if err != nil {
+		t.Fatalf("Failed to open hint file: %v", err)
+	}
+
+	// Read first entry
+	entry, err := reader.Read()
+	if err != nil {
+		t.Fatalf("Failed to read first hint entry: %v", err)
+	}
+
+	if string(entry.Key) != "key1" {
+		t.Errorf("Expected key1, got %s", string(entry.Key))
+	}
+
+	// Close reader before reading the second entry
+	err = reader.Close()
+	if err != nil {
+		t.Fatalf("Failed to close hint file: %v", err)
+	}
+
+	// Reopen and read all entries
+	reader = &HintFileReader{}
+	err = reader.Open(hintPath)
+	if err != nil {
+		t.Fatalf("Failed to reopen hint file: %v", err)
+	}
+	defer reader.Close()
+
+	// Read all entries
+	readCount := 0
+	for {
+		_, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("Failed to read hint entry: %v", err)
+		}
+		readCount++
+	}
+
+	if readCount != len(entries) {
+		t.Errorf("Expected to read %d entries, got %d", len(entries), readCount)
+	}
+}
+
+func TestGetHintPath(t *testing.T) {
+	dir := "/tmp/nutsdb"
+	fid := int64(123)
+	expected := "/tmp/nutsdb/123.hint"
+	actual := getHintPath(fid, dir)
+	if actual != expected {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}

--- a/merge_bench_test.go
+++ b/merge_bench_test.go
@@ -1,0 +1,76 @@
+package nutsdb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkMergeVariants(b *testing.B) {
+	modes := []mergeTestMode{{name: "legacy", enableMergeV2: false}, {name: "mergev2", enableMergeV2: true}}
+	for _, mode := range modes {
+		mode := mode
+		b.Run(mode.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				dir := filepath.Join(os.TempDir(), fmt.Sprintf("nutsdb-merge-bench-%s-%d", mode.name, i))
+				removeDir(dir)
+
+				opts := DefaultOptions
+				opts.Dir = dir
+				opts.SegmentSize = 32 * KB
+				opts.EnableHintFile = true
+				opts.EnableMergeV2 = mode.enableMergeV2
+
+				db, err := Open(opts)
+				if err != nil {
+					b.Fatalf("open db: %v", err)
+				}
+
+				bucket := "bench"
+				if err := db.Update(func(tx *Tx) error {
+					return tx.NewBucket(DataStructureBTree, bucket)
+				}); err != nil {
+					b.Fatalf("create bucket: %v", err)
+				}
+
+				entries := 2000
+				if err := db.Update(func(tx *Tx) error {
+					for j := 0; j < entries; j++ {
+						key := []byte(fmt.Sprintf("key-%06d", j))
+						value := []byte(fmt.Sprintf("value-%06d", j))
+						if err := tx.Put(bucket, key, value, Persistent); err != nil {
+							return err
+						}
+					}
+					return nil
+				}); err != nil {
+					b.Fatalf("populate data: %v", err)
+				}
+
+				if err := db.Update(func(tx *Tx) error {
+					for j := 0; j < entries/2; j++ {
+						key := []byte(fmt.Sprintf("key-%06d", j))
+						if err := tx.Delete(bucket, key); err != nil {
+							return err
+						}
+					}
+					return nil
+				}); err != nil {
+					b.Fatalf("delete data: %v", err)
+				}
+
+				b.StartTimer()
+				if err := db.Merge(); err != nil {
+					b.Fatalf("merge: %v", err)
+				}
+				b.StopTimer()
+
+				if err := db.Close(); err != nil {
+					b.Fatalf("close db: %v", err)
+				}
+				removeDir(dir)
+			}
+		})
+	}
+}

--- a/merge_manifest.go
+++ b/merge_manifest.go
@@ -1,0 +1,65 @@
+package nutsdb
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type mergeManifestStatus string
+
+const (
+	mergeManifestFileName       = "merge_manifest.json"
+	mergeManifestTempFileSuffix = ".tmp"
+
+	manifestStatusWriting   mergeManifestStatus = "writing"
+	manifestStatusCommitted mergeManifestStatus = "committed"
+)
+
+type mergeManifest struct {
+	Status            mergeManifestStatus `json:"status"`
+	MergeSeqMax       int                 `json:"mergeSeqMax"`
+	PendingOldFileIDs []int64             `json:"pendingOldFileIDs"`
+}
+
+func loadMergeManifest(dir string) (*mergeManifest, error) {
+	path := filepath.Join(dir, mergeManifestFileName)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read merge manifest: %w", err)
+	}
+	var manifest mergeManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode merge manifest: %w", err)
+	}
+	return &manifest, nil
+}
+
+func writeMergeManifest(dir string, manifest *mergeManifest) error {
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("encode merge manifest: %w", err)
+	}
+	manifestPath := filepath.Join(dir, mergeManifestFileName)
+	tmpPath := manifestPath + mergeManifestTempFileSuffix
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write manifest tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, manifestPath); err != nil {
+		return fmt.Errorf("rename manifest tmp: %w", err)
+	}
+	return nil
+}
+
+func removeMergeManifest(dir string) error {
+	path := filepath.Join(dir, mergeManifestFileName)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove merge manifest: %w", err)
+	}
+	return nil
+}

--- a/merge_recovery.go
+++ b/merge_recovery.go
@@ -1,0 +1,50 @@
+package nutsdb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func (db *DB) recoverMergeManifest() error {
+	manifest, err := loadMergeManifest(db.opt.Dir)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return nil
+	}
+
+	switch manifest.Status {
+	case manifestStatusWriting:
+		keep := make(map[int64]struct{}, len(manifest.PendingOldFileIDs))
+		for _, fid := range manifest.PendingOldFileIDs {
+			if !IsMergeFile(fid) {
+				continue
+			}
+			keep[fid] = struct{}{}
+		}
+		if err := purgeMergeFiles(db.opt.Dir, keep); err != nil {
+			return fmt.Errorf("purge stale merge files: %w", err)
+		}
+		if err := removeMergeManifest(db.opt.Dir); err != nil {
+			return err
+		}
+	case manifestStatusCommitted:
+		for _, fid := range manifest.PendingOldFileIDs {
+			if err := os.Remove(getDataPath(fid, db.opt.Dir)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove old data file %d: %w", fid, err)
+			}
+			if err := os.Remove(getHintPath(fid, db.opt.Dir)); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove old hint file %d: %w", fid, err)
+			}
+		}
+		if err := removeMergeManifest(db.opt.Dir); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown merge manifest status %q", manifest.Status)
+	}
+
+	return nil
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -16,6 +16,7 @@ package nutsdb
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -24,170 +25,215 @@ import (
 	"github.com/xujiajun/utils/strconv2"
 )
 
-func TestDB_MergeForString(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-string-merge/"
+type mergeTestMode struct {
+	name          string
+	enableMergeV2 bool
+}
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
-		opts.EntryIdxMode = idxMode
-		db, err := Open(opts)
-		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-		require.NoError(t, err)
-
-		// Merge is not needed
-		err = db.Merge()
-		require.Equal(t, ErrDontNeedMerge, err)
-
-		// Add some data
-		n := 1000
-		for i := 0; i < n; i++ {
-			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-		}
-
-		// Delete some data
-		for i := 0; i < n/2; i++ {
-			txDel(t, db, bucket, GetTestBytes(i), nil)
-		}
-
-		// Merge and check the result
-		require.NoError(t, db.Merge())
-
-		dbCnt, err := db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// Check the deleted data is deleted
-		for i := 0; i < n/2; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Check the added data is added
-		for i := n / 2; i < n; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-
-		// Close and reopen the db
-		require.NoError(t, db.Close())
-
-		db, err = Open(opts)
-		require.NoError(t, err)
-
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// Check the deleted data is deleted
-		for i := 0; i < n/2; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Check the added data is added
-		for i := n / 2; i < n; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-
-		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+func runForMergeModes(t *testing.T, fn func(t *testing.T, mode mergeTestMode)) {
+	modes := []mergeTestMode{{name: "mergeLegacy", enableMergeV2: false}, {name: "mergev2", enableMergeV2: true}}
+	for _, mode := range modes {
+		mode := mode
+		t.Run(mode.name, func(t *testing.T) {
+			fn(t, mode)
+		})
 	}
 }
 
-func TestDB_MergeForSet(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-set-merge/"
+type mergeFileSets struct {
+	userIDs  []int64
+	mergeIDs []int64
+}
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
+func collectMergeFileSets(t *testing.T, dir string) mergeFileSets {
+	userIDs, mergeIDs, err := enumerateDataFileIDs(dir)
+	require.NoError(t, err)
+	return mergeFileSets{userIDs: userIDs, mergeIDs: mergeIDs}
+}
 
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
-		opts.EntryIdxMode = idxMode
-		db, err := Open(opts)
-		if exist := db.bm.ExistBucket(DataStructureSet, bucket); !exist {
-			txCreateBucket(t, db, DataStructureSet, bucket, nil)
-		}
-
-		require.NoError(t, err)
-
-		// Merge is not needed
-		err = db.Merge()
-		require.Equal(t, ErrDontNeedMerge, err)
-
-		// Add some data
-		n := 1000
-		key := GetTestBytes(0)
-		for i := 0; i < n; i++ {
-			txSAdd(t, db, bucket, key, GetTestBytes(i), nil, nil)
-		}
-
-		// Delete some data
-		for i := 0; i < n/2; i++ {
-			txSRem(t, db, bucket, key, GetTestBytes(i), nil)
-		}
-
-		// Pop a random value
-		var spopValue []byte
-		err = db.Update(func(tx *Tx) error {
-			var err error
-			spopValue, err = tx.SPop(bucket, key)
-			assertErr(t, err, nil)
-			return nil
-		})
-		require.NoError(t, err)
-
-		// Check the random value is popped
-		txSIsMember(t, db, bucket, key, spopValue, false)
-
-		// txSPop(t, db, bucket, key,nil)
-		dbCnt, err := db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2-1), dbCnt)
-
-		// Merge and check the result
-		require.NoError(t, db.Merge())
-
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2-1), dbCnt)
-
-		// Check the random value is popped
-		txSIsMember(t, db, bucket, key, spopValue, false)
-		for i := n / 2; i < n; i++ {
-			v := GetTestBytes(i)
-			if bytes.Equal(v, spopValue) {
-				continue
-			}
-			txSIsMember(t, db, bucket, key, v, true)
-		}
-
-		// Close and reopen the db
-		require.NoError(t, db.Close())
-
-		// reopen db
-		db, err = Open(opts)
-		require.NoError(t, err)
-
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2-1), dbCnt)
-
-		// Check the random value is popped
-		txSIsMember(t, db, bucket, key, spopValue, false)
-		for i := n / 2; i < n; i++ {
-			v := GetTestBytes(i)
-			if bytes.Equal(v, spopValue) {
-				continue
-			}
-			txSIsMember(t, db, bucket, key, v, true)
-		}
-		require.NoError(t, db.Close())
-		removeDir(opts.Dir)
+func dataFileIDsForMode(mode mergeTestMode, sets mergeFileSets) []int64 {
+	if mode.enableMergeV2 {
+		return sets.mergeIDs
 	}
+	return sets.userIDs
+}
+
+func unionDataFileIDs(sets mergeFileSets) []int64 {
+	ids := make([]int64, 0, len(sets.userIDs)+len(sets.mergeIDs))
+	ids = append(ids, sets.userIDs...)
+	ids = append(ids, sets.mergeIDs...)
+	return ids
+}
+
+func TestDB_MergeForString(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.EnableMergeV2 = mode.enableMergeV2
+		opts.Dir = fmt.Sprintf("/tmp/test-string-merge-%s/", mode.name)
+
+		// Clean the test directory at the start
+		removeDir(opts.Dir)
+
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
+			db, err := Open(opts)
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+			require.NoError(t, err)
+
+			// Merge is not needed
+			err = db.Merge()
+			require.Equal(t, ErrDontNeedMerge, err)
+
+			// Add some data
+			n := 1000
+			for i := 0; i < n; i++ {
+				txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+			}
+
+			// Delete some data
+			for i := 0; i < n/2; i++ {
+				txDel(t, db, bucket, GetTestBytes(i), nil)
+			}
+
+			// Merge and check the result
+			require.NoError(t, db.Merge())
+
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// Check the deleted data is deleted
+			for i := 0; i < n/2; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check the added data is added
+			for i := n / 2; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+
+			// Close and reopen the db
+			require.NoError(t, db.Close())
+
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// Check the deleted data is deleted
+			for i := 0; i < n/2; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check the added data is added
+			for i := n / 2; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+
+			require.NoError(t, db.Close())
+		}
+		removeDir(opts.Dir)
+	})
+}
+
+func TestDB_MergeForSet(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.EnableMergeV2 = mode.enableMergeV2
+		opts.Dir = fmt.Sprintf("/tmp/test-set-merge-%s/", mode.name)
+
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
+			db, err := Open(opts)
+			if exist := db.bm.ExistBucket(DataStructureSet, bucket); !exist {
+				txCreateBucket(t, db, DataStructureSet, bucket, nil)
+			}
+
+			require.NoError(t, err)
+
+			// Merge is not needed
+			err = db.Merge()
+			require.Equal(t, ErrDontNeedMerge, err)
+
+			// Add some data
+			n := 1000
+			key := GetTestBytes(0)
+			for i := 0; i < n; i++ {
+				txSAdd(t, db, bucket, key, GetTestBytes(i), nil, nil)
+			}
+
+			// Delete some data
+			for i := 0; i < n/2; i++ {
+				txSRem(t, db, bucket, key, GetTestBytes(i), nil)
+			}
+
+			// Pop a random value
+			var spopValue []byte
+			err = db.Update(func(tx *Tx) error {
+				var err error
+				spopValue, err = tx.SPop(bucket, key)
+				assertErr(t, err, nil)
+				return nil
+			})
+			require.NoError(t, err)
+
+			// Check the random value is popped
+			txSIsMember(t, db, bucket, key, spopValue, false)
+
+			// txSPop(t, db, bucket, key,nil)
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2-1), dbCnt)
+
+			// Merge and check the result
+			require.NoError(t, db.Merge())
+
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2-1), dbCnt)
+
+			// Check the random value is popped
+			txSIsMember(t, db, bucket, key, spopValue, false)
+			for i := n / 2; i < n; i++ {
+				v := GetTestBytes(i)
+				if bytes.Equal(v, spopValue) {
+					continue
+				}
+				txSIsMember(t, db, bucket, key, v, true)
+			}
+
+			// Close and reopen the db
+			require.NoError(t, db.Close())
+
+			// reopen db
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2-1), dbCnt)
+
+			// Check the random value is popped
+			txSIsMember(t, db, bucket, key, spopValue, false)
+			for i := n / 2; i < n; i++ {
+				v := GetTestBytes(i)
+				if bytes.Equal(v, spopValue) {
+					continue
+				}
+				txSIsMember(t, db, bucket, key, v, true)
+			}
+			require.NoError(t, db.Close())
+		}
+		removeDir(opts.Dir)
+	})
 }
 
 // TestDB_MergeForZSet is a test function to check the Merge() function of the DB struct
@@ -195,588 +241,596 @@ func TestDB_MergeForSet(t *testing.T) {
 // It then removes half of the items from the DB, then checks that the items that are left are the same as the ones that were removed
 // It then closes the DB, reopens it, and checks that the items that were removed are now not present
 func TestDB_MergeForZSet(t *testing.T) {
-	bucket := "bucket"
-	key := GetTestBytes(0)
-	n := 1000
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-zset-merge/"
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		key := GetTestBytes(0)
+		n := 1000
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.EnableMergeV2 = mode.enableMergeV2
+		opts.Dir = fmt.Sprintf("/tmp/test-zset-merge-%s/", mode.name)
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
+		// test different EntryIdxMode
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
+			db, err := Open(opts)
+			if exist := db.bm.ExistBucket(DataStructureSortedSet, bucket); !exist {
+				txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+			}
+			require.NoError(t, err)
 
-	// test different EntryIdxMode
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			// add items
+			err = db.Merge()
+			require.Equal(t, ErrDontNeedMerge, err)
 
-		opts.EntryIdxMode = idxMode
-		db, err := Open(opts)
-		if exist := db.bm.ExistBucket(DataStructureSortedSet, bucket); !exist {
-			txCreateBucket(t, db, DataStructureSortedSet, bucket, nil)
+			for i := 0; i < n; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZAdd(t, db, bucket, key, GetTestBytes(i), score, nil, nil)
+			}
+
+			for i := 0; i < n; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
+			}
+
+			// remove half of the items
+			for i := 0; i < n/2; i++ {
+				txZRem(t, db, bucket, key, GetTestBytes(i), nil)
+			}
+
+			// check that the items that are left are the same as the ones that were removed
+			for i := 0; i < n/2; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
+			}
+
+			// check that the items that are left are the same as the ones that were removed
+			for i := n / 2; i < n; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
+			}
+
+			// check that the number of items in the DB is correct
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// merge
+			require.NoError(t, db.Merge())
+
+			// check that the number of items in the DB is correct
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// check that the items that were removed are now not present
+			for i := 0; i < n/2; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
+			}
+
+			// check that the items that are left are the same as the ones that were removed
+			for i := n / 2; i < n; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
+			}
+
+			// close db
+			require.NoError(t, db.Close())
+
+			// reopen db
+			db, err = Open(opts)
+			require.NoError(t, err)
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// check that the items that were removed are now not present
+			for i := 0; i < n/2; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
+			}
+
+			// check that the items that are left are the same as the ones that were removed
+			for i := n / 2; i < n; i++ {
+				score, _ := strconv2.IntToFloat64(i)
+				txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
+			}
+
+			require.NoError(t, db.Close())
 		}
-		require.NoError(t, err)
-
-		// add items
-		err = db.Merge()
-		require.Equal(t, ErrDontNeedMerge, err)
-
-		for i := 0; i < n; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZAdd(t, db, bucket, key, GetTestBytes(i), score, nil, nil)
-		}
-
-		for i := 0; i < n; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
-		}
-
-		// remove half of the items
-		for i := 0; i < n/2; i++ {
-			txZRem(t, db, bucket, key, GetTestBytes(i), nil)
-		}
-
-		// check that the items that are left are the same as the ones that were removed
-		for i := 0; i < n/2; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
-		}
-
-		// check that the items that are left are the same as the ones that were removed
-		for i := n / 2; i < n; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
-		}
-
-		// check that the number of items in the DB is correct
-		dbCnt, err := db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// merge
-		require.NoError(t, db.Merge())
-
-		// check that the number of items in the DB is correct
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// check that the items that were removed are now not present
-		for i := 0; i < n/2; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
-		}
-
-		// check that the items that are left are the same as the ones that were removed
-		for i := n / 2; i < n; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
-		}
-
-		// close db
-		require.NoError(t, db.Close())
-
-		// reopen db
-		db, err = Open(opts)
-		require.NoError(t, err)
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// check that the items that were removed are now not present
-		for i := 0; i < n/2; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, ErrSortedSetMemberNotExist)
-		}
-
-		// check that the items that are left are the same as the ones that were removed
-		for i := n / 2; i < n; i++ {
-			score, _ := strconv2.IntToFloat64(i)
-			txZScore(t, db, bucket, key, GetTestBytes(i), score, nil)
-		}
-
-		require.NoError(t, db.Close())
 		removeDir(opts.Dir)
-	}
+	})
 }
 
 // TestDB_MergeForList tests the Merge() function of the DB struct.
 // It creates a DB with two different EntryIdxMode, pushes and pops data, and then merges the DB.
 // It then reopens the DB and checks that the data is still there.
 func TestDB_MergeForList(t *testing.T) {
-	bucket := "bucket"
-	key := GetTestBytes(0)
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-list-merge/"
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		key := GetTestBytes(0)
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.EnableMergeV2 = mode.enableMergeV2
+		opts.Dir = fmt.Sprintf("/tmp/test-list-merge-%s/", mode.name)
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
+		// test different EntryIdxMode
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
+			db, err := Open(opts)
+			if exist := db.bm.ExistBucket(DataStructureList, bucket); !exist {
+				txCreateBucket(t, db, DataStructureList, bucket, nil)
+			}
 
-	// test different EntryIdxMode
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
-		opts.EntryIdxMode = idxMode
-		db, err := Open(opts)
-		if exist := db.bm.ExistBucket(DataStructureList, bucket); !exist {
-			txCreateBucket(t, db, DataStructureList, bucket, nil)
+			require.NoError(t, err)
+
+			// check that we don't need merge
+			err = db.Merge()
+			require.Equal(t, ErrDontNeedMerge, err)
+
+			// push data
+			n := 1000
+			for i := 0; i < n; i++ {
+				txPush(t, db, bucket, key, GetTestBytes(i), true, nil, nil)
+			}
+
+			for i := n; i < 2*n; i++ {
+				txPush(t, db, bucket, key, GetTestBytes(i), false, nil, nil)
+			}
+
+			// pop data
+			for i := n - 1; i >= n/2; i-- {
+				txPop(t, db, bucket, key, GetTestBytes(i), nil, true)
+			}
+
+			for i := 2*n - 1; i >= 3*n/2; i-- {
+				txPop(t, db, bucket, key, GetTestBytes(i), nil, false)
+			}
+
+			// trim and remove data
+			txLTrim(t, db, bucket, key, 0, 9, nil)
+			txLRem(t, db, bucket, key, 0, GetTestBytes(100), nil)
+			txLRemByIndex(t, db, bucket, key, nil, []int{7, 8, 9}...)
+
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(7), dbCnt)
+
+			// merge
+			require.NoError(t, db.Merge())
+
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(7), dbCnt)
+
+			require.NoError(t, db.Close())
+
+			// reopen db
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(7), dbCnt)
+
+			// pop data
+			for i := n/2 - 1; i < n/2-8; i-- {
+				txPop(t, db, bucket, key, GetTestBytes(i), nil, true)
+			}
+
+			require.NoError(t, db.Close())
 		}
-
-		require.NoError(t, err)
-
-		// check that we don't need merge
-		err = db.Merge()
-		require.Equal(t, ErrDontNeedMerge, err)
-
-		// push data
-		n := 1000
-		for i := 0; i < n; i++ {
-			txPush(t, db, bucket, key, GetTestBytes(i), true, nil, nil)
-		}
-
-		for i := n; i < 2*n; i++ {
-			txPush(t, db, bucket, key, GetTestBytes(i), false, nil, nil)
-		}
-
-		// pop data
-		for i := n - 1; i >= n/2; i-- {
-			txPop(t, db, bucket, key, GetTestBytes(i), nil, true)
-		}
-
-		for i := 2*n - 1; i >= 3*n/2; i-- {
-			txPop(t, db, bucket, key, GetTestBytes(i), nil, false)
-		}
-
-		// trim and remove data
-		txLTrim(t, db, bucket, key, 0, 9, nil)
-		txLRem(t, db, bucket, key, 0, GetTestBytes(100), nil)
-		txLRemByIndex(t, db, bucket, key, nil, []int{7, 8, 9}...)
-
-		dbCnt, err := db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(7), dbCnt)
-
-		// merge
-		require.NoError(t, db.Merge())
-
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(7), dbCnt)
-
-		require.NoError(t, db.Close())
-
-		// reopen db
-		db, err = Open(opts)
-		require.NoError(t, err)
-
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(7), dbCnt)
-
-		// pop data
-		for i := n/2 - 1; i < n/2-8; i-- {
-			txPop(t, db, bucket, key, GetTestBytes(i), nil, true)
-		}
-
-		require.NoError(t, db.Close())
 		removeDir(opts.Dir)
-	}
+	})
 }
 
 func TestDB_MergeWithHintFile(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	(opts.Dir) = "/tmp/test-merge-hintfile/"
-	opts.EnableHintFile = true
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.Dir = fmt.Sprintf("/tmp/test-merge-hintfile-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
 
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
+		for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
+			removeDir(opts.Dir)
+			opts.EntryIdxMode = idxMode
 
-	for _, idxMode := range []EntryIdxMode{HintKeyValAndRAMIdxMode, HintKeyAndRAMIdxMode} {
-		opts.EntryIdxMode = idxMode
+			// First, create a database with some data
+			db, err := Open(opts)
+			require.NoError(t, err)
+			txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
-		// First, create a database with some data
+			// Add some data to create multiple data files
+			n := 2000
+			for i := 0; i < n; i++ {
+				txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+			}
+
+			// Delete some data to create dirty entries
+			for i := 0; i < n/2; i++ {
+				txDel(t, db, bucket, GetTestBytes(i), nil)
+			}
+
+			// Close and reopen to ensure data is persisted
+			require.NoError(t, db.Close())
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			// Perform merge
+			require.NoError(t, db.Merge())
+
+			// Collect data file sets and select the relevant IDs for this mode
+			sets := collectMergeFileSets(t, opts.Dir)
+			idsToCheck := dataFileIDsForMode(mode, sets)
+			require.Greater(t, len(idsToCheck), 0)
+
+			// Count total entries across all merged files' hint files
+			totalHintEntryCount := 0
+			for _, fid := range idsToCheck {
+				hintPath := getHintPath(fid, opts.Dir)
+
+				// Verify hint file exists
+				_, err = os.Stat(hintPath)
+				require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
+
+				// Verify hint file content
+				reader := &HintFileReader{}
+				err = reader.Open(hintPath)
+				require.NoError(t, err)
+
+				// Count entries in this hint file
+				hintEntryCount := 0
+				for {
+					_, err := reader.Read()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					hintEntryCount++
+				}
+				reader.Close()
+
+				totalHintEntryCount += hintEntryCount
+			}
+
+			// Should have n/2 entries (the non-deleted ones) across all hint files
+			require.Equal(t, n/2, totalHintEntryCount)
+
+			// Verify data consistency after merge
+			dbCnt, err := db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// Check the deleted data is deleted
+			for i := 0; i < n/2; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check the remaining data exists
+			for i := n / 2; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+
+			// Close and reopen to test hint file loading
+			require.NoError(t, db.Close())
+			db, err = Open(opts)
+			require.NoError(t, err)
+
+			// Verify data is still correct after reopening with hint file
+			dbCnt, err = db.getRecordCount()
+			require.NoError(t, err)
+			require.Equal(t, int64(n/2), dbCnt)
+
+			// Check the deleted data is still deleted
+			for i := 0; i < n/2; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+			}
+
+			// Check the remaining data still exists
+			for i := n / 2; i < n; i++ {
+				txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+			}
+
+			require.NoError(t, db.Close())
+		}
+		removeDir(opts.Dir)
+	})
+}
+
+func TestDB_MergeHintFileCleanup(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.Dir = fmt.Sprintf("/tmp/test-merge-hintfile-cleanup-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		// Create a database with some data
 		db, err := Open(opts)
 		require.NoError(t, err)
 		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
 
-		// Add some data to create multiple data files
-		n := 2000
+		// Add enough data to create multiple files
+		n := 500
 		for i := 0; i < n; i++ {
 			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
 		}
 
-		// Delete some data to create dirty entries
-		for i := 0; i < n/2; i++ {
+		// Delete some data to trigger merge
+		for i := 0; i < n/4; i++ {
 			txDel(t, db, bucket, GetTestBytes(i), nil)
 		}
 
-		// Get initial file IDs
-		_, _ = db.getMaxFileIDAndFileIDs()
+		// Get initial file IDs before merge (legacy files only)
+		_, initialFileIDs := db.getMaxFileIDAndFileIDs()
 
-		// Close and reopen to ensure data is persisted
-		require.NoError(t, db.Close())
-		db, err = Open(opts)
-		require.NoError(t, err)
+		// Create hint files for initial files manually to test cleanup
+		for _, fileID := range initialFileIDs {
+			hintPath := getHintPath(fileID, opts.Dir)
+			writer := &HintFileWriter{}
+			err := writer.Create(hintPath)
+			require.NoError(t, err)
+
+			// Write a dummy entry
+			entry := &HintEntry{
+				BucketId:  1,
+				KeySize:   3,
+				ValueSize: 3,
+				Timestamp: 1234567890,
+				TTL:       3600,
+				Flag:      DataSetFlag,
+				Status:    Committed,
+				Ds:        DataStructureBTree,
+				DataPos:   100,
+				FileID:    fileID,
+				Key:       []byte("key"),
+			}
+
+			err = writer.Write(entry)
+			require.NoError(t, err)
+			err = writer.Close()
+			require.NoError(t, err)
+		}
+
+		// Verify hint files exist before merge
+		for _, fileID := range initialFileIDs {
+			hintPath := getHintPath(fileID, opts.Dir)
+			_, err := os.Stat(hintPath)
+			require.NoError(t, err, "Hint file should exist before merge")
+		}
 
 		// Perform merge
 		require.NoError(t, db.Merge())
 
-		// Check that hint files are created for the merged files
-		_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-		require.Greater(t, len(mergedFileIDs), 0)
+		// Verify old hint files are cleaned up
+		for _, fileID := range initialFileIDs {
+			hintPath := getHintPath(fileID, opts.Dir)
+			_, err := os.Stat(hintPath)
+			if err == nil {
+				t.Errorf("Old hint file %s should be cleaned up after merge", hintPath)
+			}
+		}
 
-		// Count total entries across all merged files' hint files
-		totalHintEntryCount := 0
-		for _, fileID := range mergedFileIDs {
-			hintPath := getHintPath(int64(fileID), opts.Dir)
+		// Verify new hint files exist for all merged files (legacy or merge v2)
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := dataFileIDsForMode(mode, sets)
+		require.Greater(t, len(idsToCheck), 0)
 
-			// Verify hint file exists
+		for _, fid := range idsToCheck {
+			newHintPath := getHintPath(fid, opts.Dir)
+			_, err = os.Stat(newHintPath)
+			require.NoError(t, err, "New hint file should exist after merge for file %d", fid)
+		}
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+func TestDB_MergeHintFileDisabled(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		bucket := "bucket"
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.Dir = fmt.Sprintf("/tmp/test-merge-hintfile-disabled-%s/", mode.name)
+		opts.EnableHintFile = false // Disable hint file
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		// Create a database with some data
+		db, err := Open(opts)
+		require.NoError(t, err)
+		txCreateBucket(t, db, DataStructureBTree, bucket, nil)
+
+		// Add some data
+		n := 500
+		for i := 0; i < n; i++ {
+			txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Delete some data to trigger merge
+		for i := 0; i < n/4; i++ {
+			txDel(t, db, bucket, GetTestBytes(i), nil)
+		}
+
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify no hint files are created
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := unionDataFileIDs(sets)
+		for _, fid := range idsToCheck {
+			hintPath := getHintPath(fid, opts.Dir)
+			_, err := os.Stat(hintPath)
+			if err == nil {
+				t.Errorf("Hint file %s should not exist when EnableHintFile is false", hintPath)
+			}
+		}
+
+		// Verify data is still correct after merge without hint files
+		dbCnt, err := db.getRecordCount()
+		require.NoError(t, err)
+		require.Equal(t, int64(3*n/4), dbCnt)
+
+		require.NoError(t, db.Close())
+		removeDir(opts.Dir)
+	})
+}
+
+func TestDB_MergeHintFileDifferentDataStructures(t *testing.T) {
+	runForMergeModes(t, func(t *testing.T, mode mergeTestMode) {
+		opts := DefaultOptions
+		opts.SegmentSize = KB
+		opts.Dir = fmt.Sprintf("/tmp/test-merge-hintfile-ds-%s/", mode.name)
+		opts.EnableHintFile = true
+		opts.EnableMergeV2 = mode.enableMergeV2
+
+		removeDir(opts.Dir)
+
+		db, err := Open(opts)
+		require.NoError(t, err)
+
+		// Test BTree
+		bucketBTree := "bucket_btree"
+		txCreateBucket(t, db, DataStructureBTree, bucketBTree, nil)
+		for i := 0; i < 100; i++ {
+			txPut(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
+		}
+
+		// Test Set
+		bucketSet := "bucket_set"
+		txCreateBucket(t, db, DataStructureSet, bucketSet, nil)
+		key := GetTestBytes(0)
+		for i := 0; i < 50; i++ {
+			txSAdd(t, db, bucketSet, key, GetTestBytes(i), nil, nil)
+		}
+
+		// Test List
+		bucketList := "bucket_list"
+		txCreateBucket(t, db, DataStructureList, bucketList, nil)
+		listKey := GetTestBytes(0)
+		for i := 0; i < 30; i++ {
+			txPush(t, db, bucketList, listKey, GetTestBytes(i), true, nil, nil)
+		}
+
+		// Test SortedSet
+		bucketZSet := "bucket_zset"
+		txCreateBucket(t, db, DataStructureSortedSet, bucketZSet, nil)
+		zsetKey := GetTestBytes(0)
+		for i := 0; i < 20; i++ {
+			txZAdd(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil, nil)
+		}
+
+		// Delete some data from each structure
+		for i := 0; i < 25; i++ {
+			txDel(t, db, bucketBTree, GetTestBytes(i), nil)
+		}
+		for i := 0; i < 10; i++ {
+			txSRem(t, db, bucketSet, key, GetTestBytes(i), nil)
+		}
+		for i := 0; i < 5; i++ {
+			txPop(t, db, bucketList, listKey, GetTestBytes(i), nil, false)
+		}
+		for i := 0; i < 5; i++ {
+			txZRem(t, db, bucketZSet, zsetKey, GetTestBytes(i), nil)
+		}
+
+		// Perform merge
+		require.NoError(t, db.Merge())
+
+		// Verify hint files exist and contain entries for all data structures
+		sets := collectMergeFileSets(t, opts.Dir)
+		idsToCheck := dataFileIDsForMode(mode, sets)
+		require.Greater(t, len(idsToCheck), 0)
+
+		// Count entries by data structure across all hint files
+		btreeCount := 0
+		setCount := 0
+		listCount := 0
+		zsetCount := 0
+
+		// Check that hint files exist for all merged files and count entries
+		for _, fid := range idsToCheck {
+			hintPath := getHintPath(fid, opts.Dir)
 			_, err = os.Stat(hintPath)
-			require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
+			require.NoError(t, err, "Hint file should exist after merge for file %d", fid)
 
 			// Verify hint file content
 			reader := &HintFileReader{}
 			err = reader.Open(hintPath)
 			require.NoError(t, err)
 
-			// Count entries in this hint file
-			hintEntryCount := 0
 			for {
-				_, err := reader.Read()
+				entry, err := reader.Read()
 				if err == io.EOF {
 					break
 				}
 				require.NoError(t, err)
-				hintEntryCount++
+
+				switch entry.Ds {
+				case DataStructureBTree:
+					btreeCount++
+				case DataStructureSet:
+					setCount++
+				case DataStructureList:
+					listCount++
+				case DataStructureSortedSet:
+					zsetCount++
+				}
 			}
 			reader.Close()
-
-			totalHintEntryCount += hintEntryCount
 		}
 
-		// Should have n/2 entries (the non-deleted ones) across all hint files
-		require.Equal(t, n/2, totalHintEntryCount)
+		// Verify counts match expected remaining entries
+		require.Equal(t, 75, btreeCount) // 100 - 25 deleted
+		require.Equal(t, 40, setCount)   // 50 - 10 deleted
+		require.Equal(t, 25, listCount)  // 30 - 5 deleted
+		require.Equal(t, 15, zsetCount)  // 20 - 5 deleted
 
-		// Verify data consistency after merge
-		dbCnt, err := db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// Check the deleted data is deleted
-		for i := 0; i < n/2; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-		}
-
-		// Check the remaining data exists
-		for i := n / 2; i < n; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
-		}
-
-		// Close and reopen to test hint file loading
+		// Verify data integrity after merge and reopen
 		require.NoError(t, db.Close())
 		db, err = Open(opts)
 		require.NoError(t, err)
 
-		// Verify data is still correct after reopening with hint file
-		dbCnt, err = db.getRecordCount()
-		require.NoError(t, err)
-		require.Equal(t, int64(n/2), dbCnt)
-
-		// Check the deleted data is still deleted
-		for i := 0; i < n/2; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
+		// Check BTree data
+		for i := 25; i < 100; i++ {
+			txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), nil)
+		}
+		for i := 0; i < 25; i++ {
+			txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
 		}
 
-		// Check the remaining data still exists
-		for i := n / 2; i < n; i++ {
-			txGet(t, db, bucket, GetTestBytes(i), GetTestBytes(i), nil)
+		// Check Set data
+		for i := 10; i < 50; i++ {
+			txSIsMember(t, db, bucketSet, key, GetTestBytes(i), true)
+		}
+		for i := 0; i < 10; i++ {
+			txSIsMember(t, db, bucketSet, key, GetTestBytes(i), false)
+		}
+
+		// Check List data
+		for i := 29; i < 24; i++ {
+			txLRange(t, db, bucketList, listKey, i-5, i-5, 1, [][]byte{GetTestBytes(i)}, nil)
+		}
+
+		// Check SortedSet data
+		for i := 5; i < 20; i++ {
+			txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil)
+		}
+		for i := 0; i < 5; i++ {
+			txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), 0, ErrSortedSetMemberNotExist)
 		}
 
 		require.NoError(t, db.Close())
 		removeDir(opts.Dir)
-	}
-}
-
-func TestDB_MergeHintFileCleanup(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-merge-hintfile-cleanup/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	// Create a database with some data
-	db, err := Open(opts)
-	require.NoError(t, err)
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Add enough data to create multiple files
-	n := 500
-	for i := 0; i < n; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Delete some data to trigger merge
-	for i := 0; i < n/4; i++ {
-		txDel(t, db, bucket, GetTestBytes(i), nil)
-	}
-
-	// Get initial file IDs before merge
-	_, initialFileIDs := db.getMaxFileIDAndFileIDs()
-
-	// Create hint files for initial files manually to test cleanup
-	for _, fileID := range initialFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		writer := &HintFileWriter{}
-		err := writer.Create(hintPath)
-		require.NoError(t, err)
-
-		// Write a dummy entry
-		entry := &HintEntry{
-			BucketId:  1,
-			KeySize:   3,
-			ValueSize: 3,
-			Timestamp: 1234567890,
-			TTL:       3600,
-			Flag:      DataSetFlag,
-			Status:    Committed,
-			Ds:        DataStructureBTree,
-			DataPos:   100,
-			FileID:    int64(fileID),
-			Key:       []byte("key"),
-		}
-
-		err = writer.Write(entry)
-		require.NoError(t, err)
-		err = writer.Close()
-		require.NoError(t, err)
-	}
-
-	// Verify hint files exist before merge
-	for _, fileID := range initialFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err := os.Stat(hintPath)
-		require.NoError(t, err, "Hint file should exist before merge")
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify old hint files are cleaned up
-	for _, fileID := range initialFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err := os.Stat(hintPath)
-		if err == nil {
-			t.Errorf("Old hint file %s should be cleaned up after merge", hintPath)
-		}
-	}
-
-	// Verify new hint files exist for all merged files
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(mergedFileIDs), 0)
-
-	// Check that hint files exist for all merged files
-	for _, fileID := range mergedFileIDs {
-		newHintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(newHintPath)
-		require.NoError(t, err, "New hint file should exist after merge for file %d", fileID)
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-func TestDB_MergeHintFileDisabled(t *testing.T) {
-	bucket := "bucket"
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-merge-hintfile-disabled/"
-	opts.EnableHintFile = false // Disable hint file
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	// Create a database with some data
-	db, err := Open(opts)
-	require.NoError(t, err)
-	txCreateBucket(t, db, DataStructureBTree, bucket, nil)
-
-	// Add some data
-	n := 500
-	for i := 0; i < n; i++ {
-		txPut(t, db, bucket, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Delete some data to trigger merge
-	for i := 0; i < n/4; i++ {
-		txDel(t, db, bucket, GetTestBytes(i), nil)
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify no hint files are created
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	for _, fileID := range mergedFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err := os.Stat(hintPath)
-		if err == nil {
-			t.Errorf("Hint file %s should not exist when EnableHintFile is false", hintPath)
-		}
-	}
-
-	// Verify data is still correct after merge without hint files
-	dbCnt, err := db.getRecordCount()
-	require.NoError(t, err)
-	require.Equal(t, int64(3*n/4), dbCnt)
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
-}
-
-func TestDB_MergeHintFileDifferentDataStructures(t *testing.T) {
-	opts := DefaultOptions
-	opts.SegmentSize = KB
-	opts.Dir = "/tmp/test-merge-hintfile-ds/"
-	opts.EnableHintFile = true
-
-	// Clean the test directory at the start
-	removeDir(opts.Dir)
-
-	db, err := Open(opts)
-	require.NoError(t, err)
-
-	// Test BTree
-	bucketBTree := "bucket_btree"
-	txCreateBucket(t, db, DataStructureBTree, bucketBTree, nil)
-	for i := 0; i < 100; i++ {
-		txPut(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), Persistent, nil, nil)
-	}
-
-	// Test Set
-	bucketSet := "bucket_set"
-	txCreateBucket(t, db, DataStructureSet, bucketSet, nil)
-	key := GetTestBytes(0)
-	for i := 0; i < 50; i++ {
-		txSAdd(t, db, bucketSet, key, GetTestBytes(i), nil, nil)
-	}
-
-	// Test List
-	bucketList := "bucket_list"
-	txCreateBucket(t, db, DataStructureList, bucketList, nil)
-	listKey := GetTestBytes(0)
-	for i := 0; i < 30; i++ {
-		txPush(t, db, bucketList, listKey, GetTestBytes(i), true, nil, nil)
-	}
-
-	// Test SortedSet
-	bucketZSet := "bucket_zset"
-	txCreateBucket(t, db, DataStructureSortedSet, bucketZSet, nil)
-	zsetKey := GetTestBytes(0)
-	for i := 0; i < 20; i++ {
-		txZAdd(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil, nil)
-	}
-
-	// Delete some data from each structure
-	for i := 0; i < 25; i++ {
-		txDel(t, db, bucketBTree, GetTestBytes(i), nil)
-	}
-	for i := 0; i < 10; i++ {
-		txSRem(t, db, bucketSet, key, GetTestBytes(i), nil)
-	}
-	for i := 0; i < 5; i++ {
-		txPop(t, db, bucketList, listKey, GetTestBytes(i), nil, false)
-	}
-	for i := 0; i < 5; i++ {
-		txZRem(t, db, bucketZSet, zsetKey, GetTestBytes(i), nil)
-	}
-
-	// Perform merge
-	require.NoError(t, db.Merge())
-
-	// Verify hint files exist and contain entries for all data structures
-	_, mergedFileIDs := db.getMaxFileIDAndFileIDs()
-	require.Greater(t, len(mergedFileIDs), 0)
-
-	// Count entries by data structure across all hint files
-	btreeCount := 0
-	setCount := 0
-	listCount := 0
-	zsetCount := 0
-
-	// Check that hint files exist for all merged files and count entries
-	for _, fileID := range mergedFileIDs {
-		hintPath := getHintPath(int64(fileID), opts.Dir)
-		_, err = os.Stat(hintPath)
-		require.NoError(t, err, "Hint file should exist after merge for file %d", fileID)
-
-		// Verify hint file content
-		reader := &HintFileReader{}
-		err = reader.Open(hintPath)
-		require.NoError(t, err)
-
-		for {
-			entry, err := reader.Read()
-			if err == io.EOF {
-				break
-			}
-			require.NoError(t, err)
-
-			switch entry.Ds {
-			case DataStructureBTree:
-				btreeCount++
-			case DataStructureSet:
-				setCount++
-			case DataStructureList:
-				listCount++
-			case DataStructureSortedSet:
-				zsetCount++
-			}
-		}
-		reader.Close()
-	}
-
-	// Verify counts match expected remaining entries
-	require.Equal(t, 75, btreeCount) // 100 - 25 deleted
-	require.Equal(t, 40, setCount)   // 50 - 10 deleted
-	require.Equal(t, 25, listCount)  // 30 - 5 deleted
-	require.Equal(t, 15, zsetCount)  // 20 - 5 deleted
-
-	// Verify data integrity after merge and reopen
-	require.NoError(t, db.Close())
-	db, err = Open(opts)
-	require.NoError(t, err)
-
-	// Check BTree data
-	for i := 25; i < 100; i++ {
-		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), nil)
-	}
-	for i := 0; i < 25; i++ {
-		txGet(t, db, bucketBTree, GetTestBytes(i), GetTestBytes(i), ErrKeyNotFound)
-	}
-
-	// Check Set data
-	for i := 10; i < 50; i++ {
-		txSIsMember(t, db, bucketSet, key, GetTestBytes(i), true)
-	}
-	for i := 0; i < 10; i++ {
-		txSIsMember(t, db, bucketSet, key, GetTestBytes(i), false)
-	}
-
-	// Check List data
-	for i := 29; i < 24; i++ {
-		txLRange(t, db, bucketList, listKey, i-5, i-5, 1, [][]byte{GetTestBytes(i)}, nil)
-	}
-
-	// Check SortedSet data
-	for i := 5; i < 20; i++ {
-		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), float64(i), nil)
-	}
-	for i := 0; i < 5; i++ {
-		txZScore(t, db, bucketZSet, zsetKey, GetTestBytes(i), 0, ErrSortedSetMemberNotExist)
-	}
-
-	require.NoError(t, db.Close())
-	removeDir(opts.Dir)
+	})
 }

--- a/merge_utils.go
+++ b/merge_utils.go
@@ -1,0 +1,127 @@
+package nutsdb
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const MergeFileIDBase int64 = math.MinInt64
+
+func GetMergeFileID(seq int) int64 {
+	return MergeFileIDBase + int64(seq)
+}
+
+func IsMergeFile(fileID int64) bool {
+	return fileID < 0
+}
+
+func GetMergeSeq(fileID int64) int {
+	return int(fileID - MergeFileIDBase)
+}
+
+func mergeFilePrefix() string {
+	return "merge_"
+}
+
+func mergeDataFileName(seq int) string {
+	return fmt.Sprintf("%s%d%s", mergeFilePrefix(), seq, DataSuffix)
+}
+
+func mergeHintFileName(seq int) string {
+	return fmt.Sprintf("%s%d%s", mergeFilePrefix(), seq, HintSuffix)
+}
+
+func mergeTempDataFileName(seq int) string {
+	return fmt.Sprintf("merge_tmp_%d%s", seq, DataSuffix)
+}
+
+func mergeTempHintFileName(seq int) string {
+	return fmt.Sprintf("merge_tmp_%d%s", seq, HintSuffix)
+}
+
+func getMergeDataPath(dir string, seq int) string {
+	return filepath.Join(dir, mergeDataFileName(seq))
+}
+
+func getMergeHintPath(dir string, seq int) string {
+	return filepath.Join(dir, mergeHintFileName(seq))
+}
+
+func getMergeTempDataPath(dir string, seq int) string {
+	return filepath.Join(dir, mergeTempDataFileName(seq))
+}
+
+func getMergeTempHintPath(dir string, seq int) string {
+	return filepath.Join(dir, mergeTempHintFileName(seq))
+}
+
+func parseMergeSeq(name string) (int, bool) {
+	if !strings.HasPrefix(name, mergeFilePrefix()) {
+		return 0, false
+	}
+	suffix := strings.TrimPrefix(name, mergeFilePrefix())
+	idx := strings.Index(suffix, ".")
+	if idx > 0 {
+		suffix = suffix[:idx]
+	}
+	seq, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return seq, true
+}
+
+func enumerateDataFileIDs(dir string) (userIDs []int64, mergeIDs []int64, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, DataSuffix) {
+			continue
+		}
+		base := strings.TrimSuffix(name, DataSuffix)
+		if seq, ok := parseMergeSeq(base); ok {
+			mergeIDs = append(mergeIDs, GetMergeFileID(seq))
+			continue
+		}
+		id, err := strconv.ParseInt(base, 10, 64)
+		if err != nil {
+			continue
+		}
+		userIDs = append(userIDs, id)
+	}
+	sort.Slice(userIDs, func(i, j int) bool { return userIDs[i] < userIDs[j] })
+	sort.Slice(mergeIDs, func(i, j int) bool { return mergeIDs[i] < mergeIDs[j] })
+	return userIDs, mergeIDs, nil
+}
+
+func purgeMergeFiles(dir string, keep map[int64]struct{}) error {
+	_, mergeIDs, err := enumerateDataFileIDs(dir)
+	if err != nil {
+		return err
+	}
+	for _, fid := range mergeIDs {
+		if keep != nil {
+			if _, ok := keep[fid]; ok {
+				continue
+			}
+		}
+		if err := os.Remove(getDataPath(fid, dir)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Remove(getHintPath(fid, dir)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/merge_v2.go
+++ b/merge_v2.go
@@ -1,0 +1,580 @@
+package nutsdb
+
+import (
+	"errors"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"io"
+	"os"
+	"sort"
+)
+
+type mergeV2Job struct {
+	db            *DB
+	pending       []int64
+	outputs       []*mergeOutput
+	lookup        []*mergeLookupEntry
+	manifest      *mergeManifest
+	oldData       []string
+	oldHints      []string
+	outputSeqBase int
+	valueHasher   hash.Hash32
+}
+
+type mergeLookupEntry struct {
+	hint         *HintEntry
+	valueHash    uint32
+	hasValueHash bool
+}
+
+type mergeOutput struct {
+	seq       int
+	fileID    int64
+	dataFile  *DataFile
+	collector *HintCollector
+	dataPath  string
+	hintPath  string
+	writeOff  int64
+	finalized bool
+}
+
+func (db *DB) mergeV2() error {
+	job := &mergeV2Job{db: db}
+	if err := job.prepare(); err != nil {
+		return err
+	}
+	defer job.finish()
+
+	if err := job.enterWritingState(); err != nil {
+		return job.abort(err)
+	}
+
+	if err := job.rewrite(); err != nil {
+		return job.abort(err)
+	}
+
+	if err := job.finalizeOutputs(); err != nil {
+		return job.abort(err)
+	}
+
+	if err := job.commit(); err != nil {
+		return job.abort(err)
+	}
+
+	if err := job.cleanupOldFiles(); err != nil {
+		return fmt.Errorf("cleanup old files: %w", err)
+	}
+
+	return nil
+}
+
+func (job *mergeV2Job) prepare() error {
+	job.db.mu.Lock()
+
+	if job.db.isMerging {
+		job.db.mu.Unlock()
+		return ErrIsMerging
+	}
+
+	userIDs, mergeIDs, err := enumerateDataFileIDs(job.db.opt.Dir)
+	if err != nil {
+		job.db.mu.Unlock()
+		return fmt.Errorf("failed to enumerate data file IDs: %w", err)
+	}
+
+	job.pending = append(job.pending, userIDs...)
+	job.pending = append(job.pending, mergeIDs...)
+
+	maxSeq := -1
+	for _, fid := range mergeIDs {
+		seq := GetMergeSeq(fid)
+		if seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	if maxSeq >= 0 {
+		job.outputSeqBase = maxSeq + 1
+	}
+	if len(job.pending) < 2 {
+		job.db.mu.Unlock()
+		return ErrDontNeedMerge
+	}
+	sort.Slice(job.pending, func(i, j int) bool { return job.pending[i] < job.pending[j] })
+
+	job.db.isMerging = true
+
+	if !job.db.opt.SyncEnable && job.db.opt.RWMode == MMap {
+		if err := job.db.ActiveFile.rwManager.Sync(); err != nil {
+			job.db.isMerging = false
+			job.db.mu.Unlock()
+			return fmt.Errorf("failed to sync active file: %w", err)
+		}
+	}
+
+	if err := job.db.ActiveFile.rwManager.Release(); err != nil {
+		job.db.isMerging = false
+		job.db.mu.Unlock()
+		return fmt.Errorf("failed to release active file: %w", err)
+	}
+
+	job.db.MaxFileID++
+	path := getDataPath(job.db.MaxFileID, job.db.opt.Dir)
+	activeFile, err := job.db.fm.getDataFile(path, job.db.opt.SegmentSize)
+	if err != nil {
+		job.db.isMerging = false
+		job.db.mu.Unlock()
+		return fmt.Errorf("failed to create new active file: %w", err)
+	}
+	job.db.ActiveFile = activeFile
+	job.db.ActiveFile.fileID = job.db.MaxFileID
+
+	job.db.mu.Unlock()
+
+	return nil
+}
+
+func (job *mergeV2Job) finish() {
+	job.db.mu.Lock()
+	job.db.isMerging = false
+	job.db.mu.Unlock()
+}
+
+func (job *mergeV2Job) enterWritingState() error {
+	job.lookup = make([]*mergeLookupEntry, 0)
+	job.manifest = &mergeManifest{
+		Status:            manifestStatusWriting,
+		MergeSeqMax:       -1,
+		PendingOldFileIDs: append([]int64(nil), job.pending...),
+	}
+	if job.valueHasher == nil {
+		job.valueHasher = fnv.New32a()
+	}
+	if err := writeMergeManifest(job.db.opt.Dir, job.manifest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (job *mergeV2Job) rewrite() error {
+	for _, fid := range job.pending {
+		if err := job.rewriteFile(fid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (job *mergeV2Job) finalizeOutputs() error {
+	if len(job.outputs) == 0 {
+		job.manifest.MergeSeqMax = -1
+		return writeMergeManifest(job.db.opt.Dir, job.manifest)
+	}
+	for _, out := range job.outputs {
+		if err := out.finalize(); err != nil {
+			return err
+		}
+	}
+	job.manifest.MergeSeqMax = job.outputs[len(job.outputs)-1].seq
+	return writeMergeManifest(job.db.opt.Dir, job.manifest)
+}
+
+func (job *mergeV2Job) commit() error {
+	job.db.mu.Lock()
+	defer job.db.mu.Unlock()
+
+	pendingSet := make(map[int64]struct{}, len(job.pending))
+	for _, fid := range job.pending {
+		pendingSet[fid] = struct{}{}
+	}
+
+	for _, entry := range job.lookup {
+		job.applyLookup(entry, pendingSet)
+	}
+
+	job.manifest.Status = manifestStatusCommitted
+	if err := writeMergeManifest(job.db.opt.Dir, job.manifest); err != nil {
+		return err
+	}
+
+	job.oldData = job.oldData[:0]
+	job.oldHints = job.oldHints[:0]
+	for _, fid := range job.pending {
+		job.oldData = append(job.oldData, getDataPath(fid, job.db.opt.Dir))
+		job.oldHints = append(job.oldHints, getHintPath(fid, job.db.opt.Dir))
+	}
+
+	return nil
+}
+
+func (job *mergeV2Job) cleanupOldFiles() error {
+	for _, path := range job.oldData {
+		_ = job.db.fm.fdm.closeByPath(path)
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	for _, path := range job.oldHints {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return removeMergeManifest(job.db.opt.Dir)
+}
+
+func (job *mergeV2Job) abort(err error) error {
+	var errs []error
+
+	// 清理所有输出文件
+	for _, out := range job.outputs {
+		if out != nil {
+			if finalizeErr := out.finalize(); finalizeErr != nil {
+				errs = append(errs, fmt.Errorf("failed to finalize output %d: %w", out.seq, finalizeErr))
+			}
+			if out.dataPath != "" {
+				if removeErr := os.Remove(out.dataPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					errs = append(errs, fmt.Errorf("failed to remove data file %s: %w", out.dataPath, removeErr))
+				}
+			}
+			if out.hintPath != "" {
+				if removeErr := os.Remove(out.hintPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					errs = append(errs, fmt.Errorf("failed to remove hint file %s: %w", out.hintPath, removeErr))
+				}
+			}
+		}
+	}
+
+	// 清理合并清单文件
+	if manifestErr := removeMergeManifest(job.db.opt.Dir); manifestErr != nil {
+		errs = append(errs, fmt.Errorf("failed to remove merge manifest: %w", manifestErr))
+	}
+
+	// 如果有清理错误，将它们添加到原始错误中
+	if len(errs) > 0 {
+		return fmt.Errorf("merge aborted with error: %w, cleanup errors: %v", err, errs)
+	}
+
+	return err
+}
+
+func (job *mergeV2Job) rewriteFile(fid int64) error {
+	path := getDataPath(fid, job.db.opt.Dir)
+	fr, err := newFileRecovery(path, job.db.opt.BufferSizeOfRecovery)
+	if err != nil {
+		return fmt.Errorf("failed to create file recovery for %s: %w", path, err)
+	}
+	defer func() {
+		if releaseErr := fr.release(); releaseErr != nil {
+			// Log the error but don't override the original error
+			// In a production environment, you might want to log this
+		}
+	}()
+
+	job.db.mu.RLock()
+	defer job.db.mu.RUnlock()
+
+	off := int64(0)
+	for {
+		if off >= fr.size {
+			break
+		}
+		entry, err := fr.readEntry(off)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, ErrIndexOutOfBound) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, ErrHeaderSizeOutOfBounds) {
+				break
+			}
+			return fmt.Errorf("merge rewrite read entry at offset %d: %w", off, err)
+		}
+		if entry == nil {
+			break
+		}
+		sz := entry.Size()
+
+		// 验证条目大小，防止无效数据导致的问题
+		if sz <= 0 {
+			off++
+			continue
+		}
+
+		off += sz
+
+		if entry.Meta.Status != Committed {
+			continue
+		}
+		if entry.isFilter() {
+			continue
+		}
+		if IsExpired(entry.Meta.TTL, entry.Meta.Timestamp) {
+			continue
+		}
+		if !job.db.isPendingMergeEntry(entry) {
+			continue
+		}
+
+		if err := job.writeEntry(entry); err != nil {
+			return fmt.Errorf("failed to write entry: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (job *mergeV2Job) writeEntry(entry *Entry) error {
+	if entry == nil {
+		return fmt.Errorf("cannot write nil entry")
+	}
+
+	data := entry.Encode()
+	if len(data) == 0 {
+		return fmt.Errorf("encoded entry is empty")
+	}
+
+	out, err := job.ensureOutput(int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("failed to ensure output: %w", err)
+	}
+
+	if out == nil {
+		return fmt.Errorf("output is nil")
+	}
+
+	offset := out.writeOff
+	if _, err := out.dataFile.WriteAt(data, offset); err != nil {
+		return fmt.Errorf("failed to write data at offset %d: %w", offset, err)
+	}
+	out.writeOff += int64(len(data))
+
+	hint := newHintEntryFromEntry(entry, out.fileID, uint64(offset))
+	if out.collector != nil {
+		if err := out.collector.Add(hint); err != nil {
+			return fmt.Errorf("failed to add hint to collector: %w", err)
+		}
+	}
+
+	lookupEntry := &mergeLookupEntry{hint: hint}
+	if entry.Meta.Ds == DataStructureSet || entry.Meta.Ds == DataStructureSortedSet {
+		h := job.valueHasher
+		h.Reset()
+		if _, err := h.Write(entry.Value); err != nil {
+			return fmt.Errorf("failed to compute value hash: %w", err)
+		}
+		lookupEntry.valueHash = h.Sum32()
+		lookupEntry.hasValueHash = true
+	}
+	job.lookup = append(job.lookup, lookupEntry)
+
+	return nil
+}
+
+func (job *mergeV2Job) ensureOutput(size int64) (*mergeOutput, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size: %d", size)
+	}
+
+	if len(job.outputs) == 0 {
+		return job.newOutput()
+	}
+
+	cur := job.outputs[len(job.outputs)-1]
+	if cur == nil {
+		return job.newOutput()
+	}
+
+	if cur.writeOff+size > job.db.opt.SegmentSize {
+		if err := cur.finalize(); err != nil {
+			return nil, fmt.Errorf("failed to finalize current output: %w", err)
+		}
+		return job.newOutput()
+	}
+	return cur, nil
+}
+
+func (job *mergeV2Job) newOutput() (*mergeOutput, error) {
+	seq := job.outputSeqBase + len(job.outputs)
+	fileID := GetMergeFileID(seq)
+	dataPath := getMergeDataPath(job.db.opt.Dir, seq)
+	hintPath := getMergeHintPath(job.db.opt.Dir, seq)
+
+	// 清理可能存在的旧文件
+	if err := os.Remove(dataPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to remove old data file %s: %w", dataPath, err)
+	}
+	if err := os.Remove(hintPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to remove old hint file %s: %w", hintPath, err)
+	}
+
+	dataFile, err := job.db.fm.getDataFileByID(job.db.opt.Dir, fileID, job.db.opt.SegmentSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get data file: %w", err)
+	}
+
+	var hintWriter *HintFileWriter
+	var collector *HintCollector
+	if job.db.opt.EnableHintFile {
+		hintWriter = &HintFileWriter{}
+		if err := hintWriter.Create(hintPath); err != nil {
+			// 如果创建 hint writer 失败，需要清理已创建的数据文件
+			_ = dataFile.Close()
+			_ = os.Remove(dataPath)
+			return nil, fmt.Errorf("failed to create hint writer: %w", err)
+		}
+		collector = NewHintCollector(fileID, hintWriter, DefaultHintCollectorFlushEvery)
+	}
+	out := &mergeOutput{
+		seq:       seq,
+		fileID:    fileID,
+		dataFile:  dataFile,
+		collector: collector,
+		dataPath:  dataPath,
+		hintPath:  hintPath,
+	}
+	job.outputs = append(job.outputs, out)
+	return out, nil
+}
+
+func (out *mergeOutput) finalize() error {
+	if out.finalized {
+		return nil
+	}
+
+	var errs []error
+
+	if out.collector != nil {
+		if err := out.collector.Close(); err != nil && !errors.Is(err, errHintCollectorClosed) {
+			errs = append(errs, fmt.Errorf("failed to close hint collector: %w", err))
+		}
+	}
+
+	if out.dataFile != nil {
+		if err := out.dataFile.Sync(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to sync data file: %w", err))
+		}
+		if err := out.dataFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close data file: %w", err))
+		}
+	}
+
+	out.finalized = true
+
+	if len(errs) > 0 {
+		return fmt.Errorf("finalize errors: %v", errs)
+	}
+
+	return nil
+}
+
+func (job *mergeV2Job) applyLookup(entry *mergeLookupEntry, pendingSet map[int64]struct{}) {
+	if entry == nil || entry.hint == nil {
+		return
+	}
+
+	hint := entry.hint
+	bucketID := BucketId(hint.BucketId)
+
+	switch hint.Ds {
+	case DataStructureBTree:
+		bt, exist := job.db.Index.bTree.exist(bucketID)
+		if !exist {
+			return
+		}
+		record, ok := bt.Find(hint.Key)
+		if !ok || record == nil {
+			return
+		}
+		if _, ok := pendingSet[record.FileID]; !ok {
+			return
+		}
+		record.FileID = hint.FileID
+		record.DataPos = hint.DataPos
+		record.Timestamp = hint.Timestamp
+		record.TTL = hint.TTL
+		record.ValueSize = hint.ValueSize
+
+	case DataStructureSet:
+		setIdx, exist := job.db.Index.set.exist(bucketID)
+		if !exist {
+			return
+		}
+		members, ok := setIdx.M[string(hint.Key)]
+		if !ok {
+			return
+		}
+		if !entry.hasValueHash {
+			return
+		}
+		record, ok := members[entry.valueHash]
+		if !ok || record == nil {
+			return
+		}
+		if _, ok := pendingSet[record.FileID]; !ok {
+			return
+		}
+		record.FileID = hint.FileID
+		record.DataPos = hint.DataPos
+		record.Timestamp = hint.Timestamp
+		record.TTL = hint.TTL
+		record.ValueSize = hint.ValueSize
+
+	case DataStructureList:
+		if hint.Flag != DataLPushFlag && hint.Flag != DataRPushFlag {
+			return
+		}
+		listIdx, exist := job.db.Index.list.exist(bucketID)
+		if !exist {
+			return
+		}
+		userKey, seq := decodeListKey(hint.Key)
+		if userKey == nil {
+			return
+		}
+		items, ok := listIdx.Items[string(userKey)]
+		if !ok {
+			return
+		}
+		record, ok := items.Find(ConvertUint64ToBigEndianBytes(seq))
+		if !ok || record == nil {
+			return
+		}
+		if _, ok := pendingSet[record.FileID]; !ok {
+			return
+		}
+		record.FileID = hint.FileID
+		record.DataPos = hint.DataPos
+		record.Timestamp = hint.Timestamp
+		record.TTL = hint.TTL
+		record.ValueSize = hint.ValueSize
+
+	case DataStructureSortedSet:
+		sortedIdx, exist := job.db.Index.sortedSet.exist(bucketID)
+		if !exist {
+			return
+		}
+		key, _ := splitStringFloat64Str(string(hint.Key), SeparatorForZSetKey)
+		if key == "" {
+			return
+		}
+		sl, ok := sortedIdx.M[key]
+		if !ok {
+			return
+		}
+		if !entry.hasValueHash {
+			return
+		}
+		node, ok := sl.dict[entry.valueHash]
+		if !ok || node == nil {
+			return
+		}
+		record := node.record
+		if record == nil {
+			return
+		}
+		if _, ok := pendingSet[record.FileID]; !ok {
+			return
+		}
+		record.FileID = hint.FileID
+		record.DataPos = hint.DataPos
+		record.Timestamp = hint.Timestamp
+		record.TTL = hint.TTL
+		record.ValueSize = hint.ValueSize
+	}
+}

--- a/merge_v2_test.go
+++ b/merge_v2_test.go
@@ -1,0 +1,321 @@
+package nutsdb
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeV2Utils(t *testing.T) {
+	t.Run("GetMergeFileID", func(t *testing.T) {
+		if got := GetMergeFileID(0); got != MergeFileIDBase {
+			t.Errorf("GetMergeFileID(0) = %d, want %d", got, MergeFileIDBase)
+		}
+		if got := GetMergeFileID(10); got != MergeFileIDBase+10 {
+			t.Errorf("GetMergeFileID(10) = %d, want %d", got, MergeFileIDBase+10)
+		}
+	})
+
+	t.Run("IsMergeFile", func(t *testing.T) {
+		if !IsMergeFile(-1) {
+			t.Error("IsMergeFile(-1) should be true")
+		}
+		if !IsMergeFile(MergeFileIDBase) {
+			t.Error("IsMergeFile(MergeFileIDBase) should be true")
+		}
+		if IsMergeFile(0) {
+			t.Error("IsMergeFile(0) should be false")
+		}
+		if IsMergeFile(100) {
+			t.Error("IsMergeFile(100) should be false")
+		}
+	})
+
+	t.Run("GetMergeSeq", func(t *testing.T) {
+		if got := GetMergeSeq(MergeFileIDBase); got != 0 {
+			t.Errorf("GetMergeSeq(MergeFileIDBase) = %d, want 0", got)
+		}
+		if got := GetMergeSeq(MergeFileIDBase + 5); got != 5 {
+			t.Errorf("GetMergeSeq(MergeFileIDBase+5) = %d, want 5", got)
+		}
+	})
+}
+
+func TestMergeV2Manifest(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("WriteAndLoad", func(t *testing.T) {
+		manifest := &mergeManifest{
+			Status:            manifestStatusWriting,
+			MergeSeqMax:       3,
+			PendingOldFileIDs: []int64{0, 1, 2, 100, 101},
+		}
+
+		if err := writeMergeManifest(dir, manifest); err != nil {
+			t.Fatalf("writeMergeManifest failed: %v", err)
+		}
+
+		loaded, err := loadMergeManifest(dir)
+		if err != nil {
+			t.Fatalf("loadMergeManifest failed: %v", err)
+		}
+		if loaded == nil {
+			t.Fatal("loaded manifest is nil")
+		}
+		if loaded.Status != manifestStatusWriting {
+			t.Errorf("Status = %v, want %v", loaded.Status, manifestStatusWriting)
+		}
+		if loaded.MergeSeqMax != 3 {
+			t.Errorf("MergeSeqMax = %d, want 3", loaded.MergeSeqMax)
+		}
+		if len(loaded.PendingOldFileIDs) != 5 {
+			t.Errorf("len(PendingOldFileIDs) = %d, want 5", len(loaded.PendingOldFileIDs))
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		if err := removeMergeManifest(dir); err != nil {
+			t.Fatalf("removeMergeManifest failed: %v", err)
+		}
+
+		loaded, err := loadMergeManifest(dir)
+		if err != nil {
+			t.Fatalf("loadMergeManifest after remove failed: %v", err)
+		}
+		if loaded != nil {
+			t.Error("manifest should be nil after removal")
+		}
+	})
+
+	t.Run("LoadNonExistent", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		loaded, err := loadMergeManifest(emptyDir)
+		if err != nil {
+			t.Fatalf("loadMergeManifest on empty dir failed: %v", err)
+		}
+		if loaded != nil {
+			t.Error("manifest should be nil for non-existent file")
+		}
+	})
+}
+
+func TestEnumerateDataFileIDs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create some test files
+	createFile := func(name string) {
+		f, err := os.Create(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+
+	createFile("0.dat")
+	createFile("1.dat")
+	createFile("100.dat")
+	createFile("merge_0.dat")
+	createFile("merge_1.dat")
+	createFile("other.txt")
+	createFile("0.hint")
+
+	userIDs, mergeIDs, err := enumerateDataFileIDs(dir)
+	if err != nil {
+		t.Fatalf("enumerateDataFileIDs failed: %v", err)
+	}
+
+	if len(userIDs) != 3 {
+		t.Errorf("len(userIDs) = %d, want 3", len(userIDs))
+	}
+	if userIDs[0] != 0 || userIDs[1] != 1 || userIDs[2] != 100 {
+		t.Errorf("userIDs = %v, want [0 1 100]", userIDs)
+	}
+
+	if len(mergeIDs) != 2 {
+		t.Errorf("len(mergeIDs) = %d, want 2", len(mergeIDs))
+	}
+	expectedMerge0 := GetMergeFileID(0)
+	expectedMerge1 := GetMergeFileID(1)
+	if mergeIDs[0] != expectedMerge0 || mergeIDs[1] != expectedMerge1 {
+		t.Errorf("mergeIDs = %v, want [%d %d]", mergeIDs, expectedMerge0, expectedMerge1)
+	}
+}
+
+func TestPurgeMergeFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	createFile := func(name string) {
+		f, err := os.Create(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+
+	createFile("0.dat")
+	createFile("merge_0.dat")
+	createFile("merge_0.hint")
+	createFile("merge_1.dat")
+
+	if err := purgeMergeFiles(dir, nil); err != nil {
+		t.Fatalf("purgeMergeFiles failed: %v", err)
+	}
+
+	// Check that merge files are gone
+	if _, err := os.Stat(filepath.Join(dir, "merge_0.dat")); !os.IsNotExist(err) {
+		t.Error("merge_0.dat should be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "merge_0.hint")); !os.IsNotExist(err) {
+		t.Error("merge_0.hint should be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "merge_1.dat")); !os.IsNotExist(err) {
+		t.Error("merge_1.dat should be deleted")
+	}
+
+	keep := map[int64]struct{}{GetMergeFileID(0): {}}
+	createFile("merge_0.dat")
+	createFile("merge_0.hint")
+	if err := purgeMergeFiles(dir, keep); err != nil {
+		t.Fatalf("purgeMergeFiles with keep failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "merge_0.dat")); err != nil {
+		t.Error("merge_0.dat should be preserved when kept")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "merge_0.hint")); err != nil {
+		t.Error("merge_0.hint should be preserved when kept")
+	}
+
+	// Check that user file remains
+	if _, err := os.Stat(filepath.Join(dir, "0.dat")); err != nil {
+		t.Error("0.dat should still exist")
+	}
+}
+
+func TestMergeV2BasicFlow(t *testing.T) {
+	dir := t.TempDir()
+	opts := DefaultOptions
+	opts.Dir = dir
+	opts.SegmentSize = 8 * 1024 // 8KB - small segment to force multiple files
+	opts.EnableMergeV2 = true
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("Close failed: %v", err)
+		}
+	}()
+
+	bucket := "test_bucket"
+
+	// Create bucket first
+	if err := db.Update(func(tx *Tx) error {
+		return tx.NewBucket(DataStructureBTree, bucket)
+	}); err != nil {
+		t.Fatalf("NewBucket failed: %v", err)
+	}
+
+	// Write enough data to create multiple files
+	// Each entry is roughly 100+ bytes, so 200 entries should create multiple 8KB files
+	for i := 0; i < 200; i++ {
+		key := []byte(fmt.Sprintf("key_%05d", i))
+		value := make([]byte, 100) // 100 bytes value
+		for j := range value {
+			value[j] = byte(i % 256)
+		}
+		if err := db.Update(func(tx *Tx) error {
+			return tx.Put(bucket, key, value, 0)
+		}); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+	}
+
+	// Update some keys to create redundancy
+	for i := 0; i < 50; i++ {
+		key := []byte(fmt.Sprintf("key_%05d", i))
+		value := make([]byte, 100)
+		for j := range value {
+			value[j] = byte((i + 200) % 256) // Different pattern for updated values
+		}
+		if err := db.Update(func(tx *Tx) error {
+			return tx.Put(bucket, key, value, 0)
+		}); err != nil {
+			t.Fatalf("Update failed: %v", err)
+		}
+	}
+
+	// Delete some keys
+	for i := 50; i < 60; i++ {
+		key := []byte(fmt.Sprintf("key_%05d", i))
+		if err := db.Update(func(tx *Tx) error {
+			return tx.Delete(bucket, key)
+		}); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+	}
+
+	// Perform merge
+	if err := db.Merge(); err != nil {
+		t.Fatalf("Merge failed: %v", err)
+	}
+
+	// Verify data integrity
+	if err := db.View(func(tx *Tx) error {
+		// Check updated keys
+		for i := 0; i < 50; i++ {
+			key := []byte(fmt.Sprintf("key_%05d", i))
+			value, err := tx.Get(bucket, key)
+			if err != nil {
+				return fmt.Errorf("get key %s: %w", key, err)
+			}
+			// Verify it's the updated value (pattern: (i+200)%256)
+			if len(value) != 100 {
+				t.Errorf("key %s: got len %d, want 100", key, len(value))
+			}
+			if value[0] != byte((i+200)%256) {
+				t.Errorf("key %s: got first byte %d, want %d", key, value[0], byte((i+200)%256))
+			}
+		}
+
+		// Check deleted keys
+		for i := 50; i < 60; i++ {
+			key := []byte(fmt.Sprintf("key_%05d", i))
+			_, err := tx.Get(bucket, key)
+			if err != ErrKeyNotFound {
+				t.Errorf("key %s should be deleted, got err: %v", key, err)
+			}
+		}
+
+		// Check remaining keys (not updated, not deleted)
+		for i := 60; i < 200; i++ {
+			key := []byte(fmt.Sprintf("key_%05d", i))
+			value, err := tx.Get(bucket, key)
+			if err != nil {
+				return fmt.Errorf("get key %s: %w", key, err)
+			}
+			// Verify it's the original value (pattern: i%256)
+			if len(value) != 100 {
+				t.Errorf("key %s: got len %d, want 100", key, len(value))
+			}
+			if value[0] != byte(i%256) {
+				t.Errorf("key %s: got first byte %d, want %d", key, value[0], byte(i%256))
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatalf("Verification failed: %v", err)
+	}
+
+	// Verify no manifest remains
+	manifest, err := loadMergeManifest(dir)
+	if err != nil {
+		t.Fatalf("loadMergeManifest failed: %v", err)
+	}
+	if manifest != nil {
+		t.Error("manifest should be removed after successful merge")
+	}
+}

--- a/metadata.go
+++ b/metadata.go
@@ -187,7 +187,7 @@ func (meta *MetaData) WithBucketId(bucketID uint64) *MetaData {
 	return meta
 }
 
-func (meta *MetaData) IsBPlusTree() bool {
+func (meta *MetaData) IsBTree() bool {
 	return meta.Ds == DataStructureBTree
 }
 

--- a/options.go
+++ b/options.go
@@ -121,6 +121,11 @@ type Options struct {
 
 	// cache size for HintKeyAndRAMIdxMode
 	HintKeyAndRAMIdxCacheSize int
+
+	// EnableHintFile represents if enable hint file feature.
+	// If EnableHintFile is true, hint files will be created and used for faster database startup.
+	// If EnableHintFile is false, hint files will not be created or used.
+	EnableHintFile bool
 }
 
 const (
@@ -150,6 +155,7 @@ var DefaultOptions = func() Options {
 		MaxBatchCount:             (15 * defaultSegmentSize / 4) / 100 / 100,
 		HintKeyAndRAMIdxCacheSize: 0,
 		ExpiredDeleteType:         TimeWheel,
+		EnableHintFile:            true,
 	}
 }()
 
@@ -254,5 +260,11 @@ func WithLessFunc(lessFunc LessFunc) Option {
 func WithMaxWriteRecordCount(maxWriteRecordCount int64) Option {
 	return func(opt *Options) {
 		opt.MaxWriteRecordCount = maxWriteRecordCount
+	}
+}
+
+func WithEnableHintFile(enable bool) Option {
+	return func(opt *Options) {
+		opt.EnableHintFile = enable
 	}
 }

--- a/options.go
+++ b/options.go
@@ -126,6 +126,10 @@ type Options struct {
 	// If EnableHintFile is true, hint files will be created and used for faster database startup.
 	// If EnableHintFile is false, hint files will not be created or used.
 	EnableHintFile bool
+
+	// EnableMergeV2 toggles the redesigned merge pipeline with deterministic merge files and manifest support.
+	// When disabled, NutsDB falls back to the legacy merge logic.
+	EnableMergeV2 bool
 }
 
 const (
@@ -156,6 +160,7 @@ var DefaultOptions = func() Options {
 		HintKeyAndRAMIdxCacheSize: 0,
 		ExpiredDeleteType:         TimeWheel,
 		EnableHintFile:            true,
+		EnableMergeV2:             false,
 	}
 }()
 
@@ -266,5 +271,11 @@ func WithMaxWriteRecordCount(maxWriteRecordCount int64) Option {
 func WithEnableHintFile(enable bool) Option {
 	return func(opt *Options) {
 		opt.EnableHintFile = enable
+	}
+}
+
+func WithEnableMergeV2(enable bool) Option {
+	return func(opt *Options) {
+		opt.EnableMergeV2 = enable
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -142,3 +142,34 @@ func TestWithLessFunc(t *testing.T) {
 	err = db.Close()
 	assert.NoError(t, err)
 }
+
+func TestWithEnableHintFile(t *testing.T) {
+	// Test default value
+	db, err := Open(DefaultOptions,
+		WithDir("/tmp/nutsdb"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, db.opt.EnableHintFile)
+	err = db.Close()
+	assert.NoError(t, err)
+
+	// Test setting to false
+	db, err = Open(DefaultOptions,
+		WithDir("/tmp/nutsdb"),
+		WithEnableHintFile(false),
+	)
+	assert.NoError(t, err)
+	assert.False(t, db.opt.EnableHintFile)
+	err = db.Close()
+	assert.NoError(t, err)
+
+	// Test setting to true explicitly
+	db, err = Open(DefaultOptions,
+		WithDir("/tmp/nutsdb"),
+		WithEnableHintFile(true),
+	)
+	assert.NoError(t, err)
+	assert.True(t, db.opt.EnableHintFile)
+	err = db.Close()
+	assert.NoError(t, err)
+}

--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -88,6 +89,10 @@ func MatchForRange(pattern, bucket string, f func(bucket string) bool) (end bool
 // getDataPath returns the data path for the given file ID.
 func getDataPath(fID int64, dir string) string {
 	separator := string(filepath.Separator)
+	if IsMergeFile(fID) {
+		seq := GetMergeSeq(fID)
+		return dir + separator + fmt.Sprintf("merge_%d%s", seq, DataSuffix)
+	}
 	return dir + separator + strconv2.Int64ToStr(fID) + DataSuffix
 }
 
@@ -178,6 +183,11 @@ func UvarintSize(x uint64) int {
 		i++
 	}
 	return i + 1
+}
+
+func VarintSize(x int64) int {
+	ux := uint64(x<<1) ^ uint64(x>>63)
+	return UvarintSize(ux)
 }
 
 // compareAndReturn use bytes.Compare(other, target), if return value is


### PR DESCRIPTION
What have I do:
- Introduced a new merge utility in `merge_utils.go` to handle merge file IDs and paths.
- Developed a redesigned merge pipeline in `merge_v2.go` that supports deterministic merge files and manifest management.
- Added tests for merge utilities and functionality in `merge_v2_test.go` to ensure correctness.
- Updated options in `options.go` to toggle the new merge functionality.
- Enhanced utility functions in `utils.go` to accommodate the new merge structure.

Todo:
- Lock granularity: The entire file scan in rewriteFile holds db.mu.RLock(); holding the lock only briefly when calling db.isPendingMergeEntry (or unlocking/relocking within the function) can shorten the window during which write transactions are blocked.
- Manifest flush frequency: Currently, stages like finalizeOutputs and commit rewrite the manifest; reusing the in-memory copy and only writing to disk when the state actually changes can reduce small file writes and fsync calls.
- Encoding cache: Each writeEntry call and newHintEntryFromEntry creates new slices for entry.Encode(). We can introduce sync.Pool or reuse []byte buffers, and have HintCollector reuse HintEntry instances to reduce GC pressure.
- Parallel rewrite: rewrite() processes all files to be merged sequentially. We can segment the files by file, start a fixed number of workers, and use fine-grained locks within each worker for accessing isPendingMergeEntry to improve throughput.
- Read path reuse: rewriteFile reopens the file with newFileRecovery(path, bufSize) each time. We could consider collecting and reusing fileRecovery or sharing buffers during the prepare phase to reduce the overhead of repeated open/close operations.