### PR TITLE
Benchmark for db watch

### DIFF
--- a/db_watch_bench_test.go
+++ b/db_watch_bench_test.go
@@ -1,0 +1,213 @@
+package nutsdb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	bucketName = "test_bucket"
+)
+
+func setupBenchmarkDBWatch(b *testing.B, dir string, incrBufferSizes bool) *DB {
+	opts := DefaultOptions
+	opts.Dir = dir
+	opts.SegmentSize = 128 * 1024 * 1024 // 128MB
+	opts.SyncEnable = false              // Disable sync for better performance
+	opts.EnableWatch = true
+
+	// modify the buffer size for benchmark
+	if incrBufferSizes {
+		watchChanBufferSize = 1024 * 1024
+		receiveChanBufferSize = 1024 * 1024
+		maxBatchSize = 1024 * 1024
+		deadMessageThreshold = 100 * 1024
+		distributeChanBufferSize = 128 * 1024
+		victimBucketBufferSize = 128 * 1024
+	}
+
+	// Clean up directory
+	_ = os.RemoveAll(dir)
+	_ = os.MkdirAll(dir, 0755)
+
+	db, err := Open(opts)
+	if err != nil {
+		b.Fatalf("Failed to open database: %v", err)
+	}
+
+	// Create test bucket
+	err = db.Update(func(tx *Tx) error {
+		return tx.NewKVBucket(bucketName)
+	})
+	if err != nil {
+		b.Fatalf("Failed to create bucket: %v", err)
+	}
+
+	return db
+}
+
+func cleanupBenchmarkDBWatch(db *DB, dir string) {
+	if db != nil && !db.IsClose() {
+		_ = db.Close()
+	}
+	_ = os.RemoveAll(dir)
+}
+
+// createValue creates a value of the specified size
+// If size is 0, creates a small default value
+func createValue(size int) []byte {
+	if size <= 0 {
+		return []byte("value")
+	}
+
+	value := make([]byte, size)
+
+	for i := 0; i < size; i++ {
+		value[i] = byte('A' + (i % 26))
+	}
+
+	return value
+}
+
+func BenchmarkWatcherManager(b *testing.B) {
+	// DISABLE GLOBAL LOGGING
+	log.SetOutput(io.Discard)
+
+	scenarios := []struct {
+		name            string
+		cntOfKeys       int
+		numWatchers     int
+		updateFreq      int  // updates per iteration
+		incrBufferSizes bool // increase the buffer sizes for benchmark
+		messageSize     int  // message size in bytes
+	}{
+		// Baseline
+		// {"single_key_single_watcher_low_freq", 1, 1, 1, true, 0},
+		// {"medium_scale_balanced", 10, 10, 5, true, 0},
+
+		// // Throughput
+		// {"single_key_single_watcher_high_freq", 1, 1, 10, true, 0},
+		// {"single_key_extreme_freq", 1, 1, 1000, true, 0},
+		// {"multi_key_very_high_freq", 10, 5, 100, true, 0},
+
+		// // Scalability
+		{"single_key_multi_watcher_low_freq", 1, 50, 1, true, 0}, // Fan-Out
+		{"hot_keys", 5, 100, 10, true, 0},                        // Asymmetric
+		{"multi_key_multi_watcher_high_freq", 50, 50, 10, true, 0},
+
+		// // DataVolume
+		// {"large_messages_1kb", 1, 1, 10, true, 1024},
+		// {"large_messages_10kb", 1, 1, 10, true, 10240},
+
+		// // Real World Scenarios
+		// {"stress_default_buffers", 10, 10, 10, false, 0}, // Small buffers
+		// {"callback_light_work", 10, 10, 10, false, 0},    // Slow consumer
+		// {"no_subscribers_baseline", 10, 0, 10, false, 0}, // Filtering cost
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			dir := b.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			db := setupBenchmarkDBWatch(b, dir, s.incrBufferSizes)
+			timesOfbenchmark := b.N
+
+			defer func() {
+				cancel()
+				cleanupBenchmarkDBWatch(db, dir)
+			}()
+
+			expectedTotal := int64(timesOfbenchmark * s.cntOfKeys * s.updateFreq)
+			b.Logf("Expected %d total", expectedTotal)
+			done := make(chan struct{})
+			var once sync.Once // Ensure done is closed only once
+
+			keys := make([][]byte, s.cntOfKeys)
+			watchers := make([]*Watcher, 0, s.cntOfKeys*s.numWatchers)
+
+			for i := 0; i < s.cntOfKeys; i++ {
+				keys[i] = fmt.Appendf(nil, "key_%d", i)
+				for j := 0; j < s.numWatchers; j++ {
+					watcher, err := db.Watch(ctx, bucketName, keys[i], func(msg *Message) error {
+						return nil
+					})
+					if err != nil {
+						b.Fatalf("Failed to watch: %v", err)
+					}
+
+					watchers = append(watchers, watcher)
+
+				}
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for _, watcher := range watchers {
+				go func(w *Watcher) {
+					err := w.Run()
+					if err != nil {
+						b.Errorf("Failed to run watcher: %v", err)
+					}
+				}(watcher)
+
+				errWait := watcher.WaitReady(10 * time.Second)
+				if errWait != nil {
+					b.Fatalf("Failed to wait for watcher: %v", errWait)
+				}
+			}
+
+			go func() {
+				ticker := time.NewTicker(10 * time.Millisecond)
+				for {
+					select {
+					case <-ticker.C:
+					default:
+						totalReceived := db.watchMgr.stats.GetTotalCount()
+						if totalReceived == expectedTotal {
+							once.Do(func() {
+								close(done)
+							})
+							return
+						}
+					}
+				}
+			}()
+
+			for i := 0; i < timesOfbenchmark; i++ {
+				for j := 0; j < s.cntOfKeys; j++ {
+					for k := 0; k < s.updateFreq; k++ {
+						err := db.Update(func(tx *Tx) error {
+							value := createValue(s.messageSize)
+							return tx.Put(bucketName, keys[j], value, Persistent)
+						})
+						if err != nil {
+							b.Fatalf("Put failed: %v", err)
+						}
+					}
+				}
+			}
+
+			// select {
+			// case <-done:
+			// 	break
+			// case <-time.After(10 * time.Second):
+			// 	totalReceived := db.watchMgr.stats.GetTotalCount()
+			// 	b.Fatalf("Timeout waiting for benchmark to finish. Expected %d total, got %d", expectedTotal, totalReceived)
+			// }
+			<-done
+
+			// wait for process all messages
+			time.Sleep(200 * time.Millisecond)
+
+			b.StopTimer()
+
+		})
+	}
+}

--- a/db_watch_bench_test.go
+++ b/db_watch_bench_test.go
@@ -18,8 +18,8 @@ const (
 func setupBenchmarkDBWatch(b *testing.B, dir string, incrBufferSizes bool) *DB {
 	opts := DefaultOptions
 	opts.Dir = dir
-	opts.SegmentSize = 128 * 1024 * 1024 // 128MB
-	opts.SyncEnable = false              // Disable sync for better performance
+	opts.SegmentSize = 128 * MB
+	opts.SyncEnable = false // Disable sync for better performance
 	opts.EnableWatch = true
 
 	// modify the buffer size for benchmark

--- a/tx.go
+++ b/tx.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync/atomic"
 
@@ -875,7 +876,7 @@ func (tx *Tx) sendUpdatedEntries(pendingWriteList []*core.Entry, deletedBuckets 
 	})
 
 	if err != nil {
-		// log.Println("send updated entries error: ", err)
+		log.Println("send updated entries error: ", err)
 	}
 }
 

--- a/tx.go
+++ b/tx.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"sync/atomic"
 
@@ -876,7 +875,7 @@ func (tx *Tx) sendUpdatedEntries(pendingWriteList []*core.Entry, deletedBuckets 
 	})
 
 	if err != nil {
-		log.Println("send updated entries error: ", err)
+		// log.Println("send updated entries error: ", err)
 	}
 }
 

--- a/tx.go
+++ b/tx.go
@@ -898,7 +898,6 @@ func (tx *Tx) getDeletedBuckets() (deletedBuckets map[core.BucketName]bool) {
 			if _, ok := deletedBuckets[name]; !ok && bucket.Meta.Op == core.BucketDeleteOperation && isAllDsDeleted {
 				deletedBuckets[name] = true
 			}
-
 		}
 	}
 


### PR DESCRIPTION
This PR details the benchmark results for wathcer. The tests are categorized by system behavior to identify performance characteristics, bottlenecks, and stability under different load profiles.

## System Specs:
- CPU: AMD Ryzen 5 5600H (6 Cores / 12 Threads)
- OS: Linux (amd64)

## Benchmark Result
### 1. Baseline & Scaling

Scenario | Cores | Config (Keys / Watchers / Freq) | Time / Batch | Time / Update (Normalized) | Memory / Batch | Memory / Update (Normalized) | Allocs / Batch | Allocs / Update (Normalized) | Note
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
single_key_single_watcher_low_freq | 1 | 1 / 1 / 1 | 9.78 µs | 9.78 µs | ~1.62 KB | ~1.62 KB | 28 | 28 | Baseline latency (1 thread).
 | | 2 | 1 / 1 / 1 | 6.13 µs | 6.13 µs | ~1.62 KB | ~1.62 KB | 28 | 28 | 37% faster than 1 core.
  | 4 | 1 / 1 / 1 | 5.18 µs | 5.18 µs | ~1.62 KB | ~1.62 KB | 28 | 28 | 47% faster. Diminishing returns after 2 cores for single key.
  |   |   |   |   |   |   |   |   |  
medium_scale_balanced | 1 | 10 / 10 / 5 | 1.10 ms | 21.94 µs | ~267.2 KB | ~5.34 KB | 4550 | 91 | High variance (±60%) on 1 core indicates contention/blocking.
| | 2 | 10 / 10 / 5 | 0.62 ms | 12.46 µs | ~267.2 KB | ~5.34 KB | 4550 | 91 | 2x throughput gain. Latency drops significantly.
| | 4 | 10 / 10 / 5 | 0.40 ms | 7.93 µs | ~267.2 KB | ~5.34 KB | 4550 | 91 | Best Performance. Per-update cost (~8µs) is near baseline (~5µs) despite 10x watchers.

### 2. Throughput & High Frequency

This group tests the system's ability to handle "bursts" of traffic. I increase the updateFreq significantly (up to 1000 updates per benchmark iteration) to see if the internal channels or locks become a bottleneck.

Total Updates per Batch Calculation:
- single_key_single_watcher_high_freq: 1 Key × 10 Updates = 10 Updates
- single_key_extreme_freq: 1 Key × 1000 Updates = 1000 Updates
- multi_key_very_high_freq: 10 Keys × 100 Updates = 1000 Updates

Scenario | Cores | Config (Keys / Watchers / Freq) | Time / Batch | Time / Update (Normalized) | Memory / Batch | Memory / Update (Normalized) | Allocs / Batch | Allocs / Update (Normalized) | Note
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
single_key_single_watcher_high_freq | 1 | 1 / 1 / 10 | 117.4 µs | 11.74 µs | ~16.18 KiB | ~1.62 KB | 280 | 28 | Slight overhead vs baseline (9.78µs) due to rapid looping.
  | 2 | 1 / 1 / 10 | 68.28 µs | 6.83 µs | ~16.18 KiB | ~1.62 KB | 280 | 28 | 41% faster. Parallel processing of the 10 updates.
  | 4 | 1 / 1 / 10 | 59.22 µs | 5.92 µs | ~16.17 KiB | ~1.62 KB | 281 | 28 | Diminishing returns. High variance (±42%) due to short burst duration.
single_key_extreme_freq | 1 | 1 / 1 / 1000 | 10.90 ms | 10.90 µs | ~1.58 MiB | ~1.62 KB | 28,000 | 28 | Burst Stability: Even with 1000 updates queued instantly, per-msg latency stays low (~10µs).
  | 2 | 1 / 1 / 1000 | 7.93 ms | 7.93 µs | ~1.58 MiB | ~1.62 KB | 28,000 | 28 | Throughput improves, handling ~126k ops/sec.
  | 4 | 1 / 1 / 1000 | 6.22 ms | 6.22 µs | ~1.58 MiB | ~1.62 KB | 28,120 | 28 | Max Throughput: ~160k ops/sec. High variance (±51%) likely due to GC triggering during large batch.
multi_key_very_high_freq | 1 | 10 / 5 / 100 | 19.79 ms | 19.79 µs | ~3.20 MiB | ~3.28 KB | 56,000 | 56 | Bottleneck: Single core struggles to switch between 10 keys and 50 total watchers.
  | 2 | 10 / 5 / 100 | 10.46 ms | 10.46 µs | ~3.20 MiB | ~3.28 KB | 56,000 | 56 | Near Linear Scaling: Adding a 2nd core almost doubles speed (19ms -> 10ms).
  | 4 | 10 / 5 / 100 | 9.04 ms | 9.04 µs | ~3.20 MiB | ~3.28 KB | 56,060 | 56 | Efficiency plateau. The cost per update (~9µs) is excellent considering it notifies 5 watchers.

### 3. Scalability 
This group evaluates the cost of broadcasting updates to many subscribers.
- Fan-Out: How expensive is it to notify 50 people about 1 change.
- Hot Keys: How does the system handle heavy traffic on specific keys that everyone is watching.
- Multi-Key: Many Keys → Moderate Watchers (Broad Distribution).

Scenario | Cores | Config (Keys / Watchers / Freq) | Time / Batch | Time / Update (Normalized) | Memory / Batch | Memory / Update (Normalized) | Allocs / Batch | Allocs / Update (Normalized) | Note
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
single_key_multi_watcher_low_freq | 1 | 1 / 50 / 1 | 90.03 µs | 90.03 µs | ~21.91 KB | ~21.91 KB | 371 | 371 | Fan-Out Cost: 1 update triggers 50 notifications.
  | 2 | 1 / 50 / 1 | 56.88 µs | 56.88 µs | ~21.90 KB | ~21.90 KB | 370 | 370 | 37% faster. Parallelism helps dispatching the 50 events.
  | 4 | 1 / 50 / 1 | 34.60 µs | 34.60 µs | ~20.83 KB | ~20.83 KB | 352 | 352 | Highly Efficient: Adding 49 extra watchers only adds ~29µs total (~0.6µs per watcher).
hot_keys | 1 | 5 / 50 / 10 | 4.99 ms | 99.88 µs | ~1.05 MB | ~21.60 KB | 18,280 | 365 | Heavy Load: Single core struggles with high memory churn (~1MB/op).
  | 2 | 5 / 50 / 10 | 2.44 ms | 48.78 µs | ~870 KB | ~17.40 KB | 14,740 | 294 | 2x Speedup: Excellent scaling. Splitting the 5 hot keys across 2 threads works perfectly.
  | 4 | 5 / 50 / 10 | 2.13 ms | 42.68 µs | ~1.03 MB | ~21.20 KB | 17,960 | 359 | Diminishing Returns: High variance (±74%) suggests lock contention on the hot keys.
multi_key_multi_watcher | 1 | 50 / 10 / 1 | 2.31 ms | 46.12 µs | ~268 KB | ~5.36 KB | 4,555 | 91 | Broad Load: 1 core is slow (2.3ms) iterating over 50 distinct keys.
  | 2 | 50 / 10 / 1 | 1.07 ms | 21.36 µs | ~267 KB | ~5.35 KB | 4,552 | 91 | Linear Scaling: >2x speedup. Parallelism shines here because updates are on different keys (less lock contention).
  | 4 | 50 / 10 / 1 | 0.77 ms | 15.42 µs | ~267 KB | ~5.35 KB | 4,551 | 91 | Efficient: Per-update cost (~15µs) is much lower than hot_keys (~42µs) because there's less contention.

### 4. Data volume
This group evaluates the impact of Payload Size on performance.
- Goal: Measure memory bandwidth overhead and copy costs.
- Mechanism: We use a fixed update frequency (10 updates) but vary the size of the value being stored (1KB vs 10KB).

Total Updates per Batch Calculation:
- large_messages_1kb: 1 Key × 10 Updates = 10 Updates
- large_messages_10kb: 1 Key × 10 Updates = 10 Updates

Scenario | Cores | Config (Keys / Watchers / Freq) | Time / Batch | Time / Update (Normalized) | Memory / Batch | Memory / Update (Normalized) | Allocs / Batch | Allocs / Update (Normalized) | Note
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
large_messages_1kb | 1 | 1 / 1 / 10 | 492.0 µs | 49.20 µs | ~36.57 KB | ~3.66 KB | 280 | 28 | Memory Copy Cost: ~49µs per update is significantly higher than the baseline (~11µs for 0-byte msgs).
  | 2 | 1 / 1 / 10 | 277.5 µs | 27.75 µs | ~36.57 KB | ~3.66 KB | 280 | 28 | Best Performance: 2 cores handle the copying and channel passing efficiently.
  | 4 | 1 / 1 / 10 | 500.8 µs | 50.08 µs | ~36.57 KB | ~3.66 KB | 281 | 28 | Regressions: Performance degrades at 4 cores (±56% variance). Likely due to CPU cache thrashing when moving larger data blocks between cores.
  |   |   |   |   |   |   |   |   |  
large_messages_10kb | 1 | 1 / 1 / 10 | 1.94 ms | 194.20 µs | ~221.6 KB | ~22.16 KB | 280 | 28 | Linear Scaling: 10x size increase (1KB -> 10KB) leads to roughly 4x latency increase (49µs -> 194µs).
  | 2 | 1 / 1 / 10 | 1.06 ms | 105.70 µs | ~221.6 KB | ~22.16 KB | 280 | 28 | Solid Speedup: 2 cores cut the time almost in half.
  | 4 | 1 / 1 / 10 | 1.01 ms | 101.10 µs | ~221.6 KB | ~22.16 KB | 283 | 28 | Bandwidth Limit: Adding more cores (4 vs 2) barely helps. The bottleneck is now memory bandwidth (copying bytes), not CPU logic.

### 5. Real World Scenarios (Stress & Filtering)
This group tests the system under realistic constraints:
- Stress: Small buffers + High Concurrency. This forces the system to handle "backpressure" where producers (Updates) might outpace consumers (Watchers).
- No Subscribers: Measures the "Filtering Cost"—the overhead of checking if a key is watched when it actually isn't.

Total Updates per Batch Calculation:
- stress_default_buffers: 10 Keys × 10 Updates = 100 Updates
- no_subscribers_baseline: 10 Keys × 10 Updates = 100 Updates

Scenario | Cores | Config (Keys / Watchers / Freq) | Time / Batch | Time / Update (Normalized) | Memory / Batch | Memory / Update (Normalized) | Allocs / Batch | Allocs / Update (Normalized) | Note
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
stress_default_buffers | 1 | 10 / 10 / 10 | 1.47 ms | 14.74 µs | ~244 KB | ~2.44 KB | 4,205 | 42 | Baseline Contention: Small buffers cause natural slowing as channels fill up.
  | 2 | 10 / 10 / 10 | 1.04 ms | 10.42 µs | ~296 KB | ~2.96 KB | 5,072 | 51 | High Variance (133%): Indicates significant fighting for channel slots (blocking/unblocking) between producer/consumer threads.
  | 4 | 10 / 10 / 10 | 1.07 ms | 10.65 µs | ~531 KB | ~5.31 KB | 9,036 | 90 | Allocation Spike: Performance plateaus, but memory/allocs double. Likely due to internal retries or queuing mechanisms triggering under high contention.
  |   |   |   |   |   |   |   |   |  
no_subscribers_baseline | 1 | 10 / 0 / 10 | 1.05 ms | 10.45 µs | ~120 KB | ~1.20 KB | 2,100 | 21 | Base Cost: ~21 allocs/op is the cost of a raw db.Update transaction in NutsDB.
  | 2 | 10 / 0 / 10 | 0.63 ms | 6.27 µs | ~120 KB | ~1.20 KB | 2,100 | 21 | Filtering Efficiency: The system efficiently skips notification logic.
  | 4 | 10 / 0 / 10 | 0.63 ms | 6.28 µs | ~120 KB | ~1.20 KB | 2,110 | 21 | Clean Overhead: Comparing this (6.28µs) to the Stress case (10.65µs) shows the notification logic adds ~4µs overhead per op.

