### PR TITLE
fix: CloseByPath should clean path and decrement cache size

### DIFF
--- a/internal/fileio/fd_manager.go
+++ b/internal/fileio/fd_manager.go
@@ -207,11 +207,13 @@ func (fdm *FdManager) cleanUselessFd() error {
 func (fdm *FdManager) CloseByPath(path string) error {
 	fdm.lock.Lock()
 	defer fdm.lock.Unlock()
-	fdInfo, ok := fdm.Cache[path]
+	cleanPath := filepath.Clean(path)
+	fdInfo, ok := fdm.Cache[cleanPath]
 	if !ok {
 		return nil
 	}
-	delete(fdm.Cache, path)
+	delete(fdm.Cache, cleanPath)
+	fdm.size--
 
 	fdm.fdList.removeNode(fdInfo)
 	return fdInfo.fd.Close()


### PR DESCRIPTION
GetFd stores cache entries under filepath.Clean(path), but CloseByPath looked up the cache with the raw path. When the DB dir contains forward slashes (e.g. D:/data/db, or /tmp/...-style paths
used in tests on Windows), the lookup misses and the fd stays open, so the following os.Remove in merge() fails with "The process cannot access the file because it is being used by another
process".

Also, CloseByPath removed the cache entry without decrementing fdm.size. Every merge leaks the counter by the number of merged files; once the accumulated value reaches maxFdNums, GetFd stops
caching fds and a later Release panics in ReduceUsing ("unexpected the node is not in cache").

This is a follow-up to #659 — verified on Windows that merge now works with both forward-slash and backslash DB dirs.